### PR TITLE
Fix docs: update repo links from ai-guidance to skills

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,8 +40,8 @@ We regularly triage issues by looking at newly filed issues and determining what
 
 At the end of a triage session, the untriaged issue list should be as close to empty as possible.
 
-[untriaged_list]: https://github.com/flutter/ai-guidance/issues?q=is%3Aissue+state%3Aopen+-label%3Atriaged
-[P0]: https://github.com/flutter/ai-guidance/labels?q=P0
-[P1]: https://github.com/flutter/ai-guidance/labels?q=P1
-[P2]: https://github.com/flutter/ai-guidance/labels?q=P2
-[P3]: https://github.com/flutter/ai-guidance/labels?q=P3
+[untriaged_list]: https://github.com/flutter/skills/issues?q=is%3Aissue+state%3Aopen+-label%3Atriaged
+[P0]: https://github.com/flutter/skills/labels?q=P0
+[P1]: https://github.com/flutter/skills/labels?q=P1
+[P2]: https://github.com/flutter/skills/labels?q=P2
+[P3]: https://github.com/flutter/skills/labels?q=P3


### PR DESCRIPTION
The issue triage links in CONTRIBUTING.md were pointing to flutter/ai-guidance repository instead of flutter/skills. This PR updates those links to point to the correct repository.