### PR TITLE
`@pragma('vm:entry-point')` requirement for isolate entry points

### DIFF
--- a/skills/flutter-handling-concurrency/SKILL.md
+++ b/skills/flutter-handling-concurrency/SKILL.md
@@ -67,6 +67,7 @@ Use this workflow for persistent background processes requiring continuous bidir
 
 **Task Progress:**
 - [ ] Instantiate a `ReceivePort` on the Main Isolate to listen for messages.
+- [ ] Define the worker entry point function and mark it with `@pragma('vm:entry-point')` to prevent tree-shaking.
 - [ ] Spawn the worker isolate using `Isolate.spawn()`, passing the `ReceivePort.sendPort` as the initial message.
 - [ ] In the worker isolate, instantiate its own `ReceivePort`.
 - [ ] Send the worker's `SendPort` back to the Main Isolate via the initial port.
@@ -155,6 +156,11 @@ class WorkerManager {
   }
 
   // 3. Worker Isolate Entry Point
+  // The @pragma annotation prevents tree-shaking of this function, as it is
+  // invoked dynamically by the VM when the isolate starts, not through
+  // regular static calls. Without this, the function may be removed in
+  // release builds, causing the isolate spawn to fail at runtime.
+  @pragma('vm:entry-point')
   static void _workerEntry(SendPort mainSendPort) {
     final workerReceivePort = ReceivePort();
     


### PR DESCRIPTION
When spawning an isolate using Isolate.spawn(), the entry point callback function is invoked dynamically by the Dart VM. Unlike regular function calls that the compiler can track through static analysis, the VM looks up this function at runtime to start the isolate's execution.

This means that during tree-shaking (a process where the compiler removes unused code to reduce app size), the entry point function may be incorrectly identified as "dead code" and removed from the compiled output. This typically only manifests in release builds, causing the app to crash or fail silently when trying to spawn the isolate.

**Solution**

Add the `@pragma('vm:entry-point')` annotation to all isolate entry point functions.

Ref: [pragmas](https://github.com/dart-lang/sdk/blob/main/runtime/docs/pragmas.md)

fixes #46 

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.
