### PR TITLE
[tool/generator test] Update resources directory path in yaml_assets_test.dart

### DIFF
--- a/tool/generator/test/yaml_assets_test.dart
+++ b/tool/generator/test/yaml_assets_test.dart
@@ -11,16 +11,16 @@ import 'package:yaml/yaml.dart';
 
 void main() {
   final resourcesDir = Directory(
-    p.normalize(p.join(Directory.current.path, '..', 'tool', 'resources')),
+    p.normalize(p.join(Directory.current.path, '..', '..', 'resources')),
   );
 
   test(
-    'tool/resources directory exists',
+    'resources directory exists',
     () {
       expect(
         resourcesDir.existsSync(),
         isTrue,
-        reason: 'tool/resources directory should exist',
+        reason: 'resources directory should exist',
       );
     },
     skip: !resourcesDir.existsSync() ? 'Directory not present' : false,
@@ -33,12 +33,8 @@ void main() {
       .where((e) => e.path.endsWith('.yaml'))
       .cast<File>();
 
-  test('tool/resources contains YAML files', () {
-    expect(
-      yamlFiles,
-      isNotEmpty,
-      reason: 'No YAML files found in tool/resources',
-    );
+  test('resources contains YAML files', () {
+    expect(yamlFiles, isNotEmpty, reason: 'No YAML files found in resources');
   });
 
   final client = http.Client();


### PR DESCRIPTION
Update the path to the resources directory to match the new location of the generator tool (moved to tool/generator). Also update test descriptions to refer to `resources` instead of `tool/resources`.