### PR TITLE
Use dart intgration for so that dart test actually validates skills

### DIFF
--- a/tool/dart_skills_lint/README.md
+++ b/tool/dart_skills_lint/README.md
@@ -45,10 +45,11 @@ dart pub global activate dart_skills_lint
 
 ## Usage
 
-Run the linter against your skills or root skills directories.
+There are three ways to interact with `dart_skills_lint`:
 
-### Project Usage
-If installed as a dev_dependency:
+### 1. As a Command Line Tool with Arguments
+Run the linter against your skills or root skills directories by passing arguments.
+
 ```bash
 dart run dart_skills_lint --skills-directory ./path/to/skills-root
 ```
@@ -73,21 +74,60 @@ If no directory is specified, it automatically checks `.claude/skills` and `.age
 - `--fast-fail`: Halt execution immediately on the error.
 - `--ignore-config`: Ignore the YAML configuration file entirely.
 
-## Configuration
+### 2. As a Command Line Tool with a YAML Configuration File
+You can configure the linter using a configuration file (defaulting to `dart_skills_lint.yaml` in the current directory).
 
-You can configure the linter using a configuration file (defaulting to `dart_skills_lint.yaml`).
-
-### Example `dart_skills_lint.yaml`
-Create this file in the root of your repository:
+Create `dart_skills_lint.yaml` in the root of your repository:
 
 ```yaml
 # dart_skills_lint.yaml
 dart_skills_lint:
   rules:
-    no-unresolved-relative-paths: error
-    valid-yaml-metadata: error
-    flat-directory-structure: warning # Can override to warning instead of error
+    check-relative-paths: error
+    check-absolute-paths: error
+  directories:
+    - path: "~/.agents/skills"
+      ignore_file: "~/.agents/skills/ignore.json"
 ```
+
+Then you can simply run:
+```bash
+dart run dart_skills_lint
+```
+
+### 3. As Dart Test Code
+You can integrate the linter into your automated tests by importing the package and calling `validateSkills`. This allows you to enforce skill validity as part of your standard test suite.
+
+Example `test/lint_skills_test.dart`:
+```dart
+import 'package:dart_skills_lint/dart_skills_lint.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Run skills linter', () async {
+    final config = Configuration(
+      directoryConfigs: [
+        DirectoryConfig(
+          path: '../../skills',
+          rules: {},
+          ignoreFile: '.agents/skills/flutter_skills_ignore.json',
+        ),
+      ],
+    );
+
+    await validateSkills(
+      skillDirPaths: ['../../skills'],
+      resolvedRules: {
+        'check-relative-paths': AnalysisSeverity.error,
+        'check-absolute-paths': AnalysisSeverity.error,
+      },
+      config: config,
+    );
+  });
+}
+```
+
+You can also use `Validator` and `ValidationResult` directly if you need to inspect the errors programmatically.
 
 ## Specification Validation
 
@@ -100,7 +140,7 @@ The linter checks against the criteria defined in `documentation/knowledge/SPECI
 
 ### 2. Metadata (YAML Frontmatter)
 - Valid YAML syntax.
-- Allowed fields: `name`, `description`, `license`, `allowed-tools`, `metadata`, `compatibility`.
+- Allowed fields: `name`, `description`, `license`, `allowed-tools`, `metadata`, `compatibility`, `category`, `tags`, `version`, `eval_task`.
 - Required fields: `name` and `description`.
 
 ### 3. Field Specific Constraints

--- a/tool/dart_skills_lint/lib/dart_skills_lint.dart
+++ b/tool/dart_skills_lint/lib/dart_skills_lint.dart
@@ -1,0 +1,9 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+export 'src/config_parser.dart';
+export 'src/entry_point.dart';
+export 'src/models/analysis_severity.dart';
+export 'src/models/validation_error.dart';
+export 'src/validator.dart';

--- a/tool/dart_skills_lint/lib/src/config_parser.dart
+++ b/tool/dart_skills_lint/lib/src/config_parser.dart
@@ -30,9 +30,17 @@ AnalysisSeverity _parseSeverity(String value) {
   return AnalysisSeverity.disabled; // Default if unknown
 }
 
-/// Configuration for a specific directory.
+/// Configuration for a specific directory containing skills.
+///
+/// Allows overriding rules and specifying a custom ignore file for skills
+/// located within this directory.
 class DirectoryConfig {
   DirectoryConfig({required this.path, required this.rules, this.ignoreFile});
+
+  /// The path to the directory containing skills.
+  ///
+  /// Can be absolute or relative to the current working directory.
+  /// Supports tilde expansion (e.g., `~/...`).
   final String path;
   final Map<String, AnalysisSeverity> rules;
   final String? ignoreFile;

--- a/tool/dart_skills_lint/lib/src/entry_point.dart
+++ b/tool/dart_skills_lint/lib/src/entry_point.dart
@@ -135,7 +135,53 @@ Future<void> runApp(List<String> args) async {
   final printWarnings = results[_printWarningsFlag] as bool;
   final fastFail = results[_fastFailFlag] as bool;
   final quiet = results[_quietFlag] as bool;
+  final generateBaseline = results[_generateBaselineFlag] as bool;
 
+  String? ignoreFileOverride;
+  if (results.wasParsed(_ignoreFileOption)) {
+    ignoreFileOverride = results[_ignoreFileOption] as String?;
+  }
+
+  final bool success = await validateSkills(
+    skillDirPaths: skillDirPaths,
+    individualSkillPaths: individualSkillPaths,
+    resolvedRules: resolvedRules,
+    printWarnings: printWarnings,
+    fastFail: fastFail,
+    quiet: quiet,
+    generateBaseline: generateBaseline,
+    ignoreFileOverride: ignoreFileOverride,
+    config: config,
+  );
+
+  exitCode = success ? 0 : 1;
+}
+
+/// Validates skills based on the provided configuration.
+///
+/// [skillDirPaths] is a list of directories containing multiple skills.
+/// [individualSkillPaths] is a list of paths to individual skill directories.
+/// [resolvedRules] is a map of rule names to their severity overrides.
+/// [printWarnings] controls whether to print validation warnings.
+/// [fastFail] causes validation to stop on the first error.
+/// [quiet] suppresses non-error/warning output.
+/// [generateBaseline] writes current errors to a baseline file instead of reporting them.
+/// [ignoreFileOverride] is an optional path to a baseline file to use.
+/// [config] is the loaded configuration.
+///
+/// Returns `true` if all validations passed (or if generating a baseline), `false` otherwise.
+Future<bool> validateSkills({
+  List<String> skillDirPaths = const [],
+  List<String> individualSkillPaths = const [],
+  Map<String, AnalysisSeverity> resolvedRules = const {},
+  bool printWarnings = true,
+  bool fastFail = false,
+  bool quiet = false,
+  bool generateBaseline = false,
+  String? ignoreFileOverride,
+  Configuration? config,
+}) async {
+  config ??= Configuration();
   var globalAnyFailed = false;
   var anySkillsValidated = false;
 
@@ -165,8 +211,8 @@ Future<void> runApp(List<String> args) async {
       }
     }
 
-    if (results.wasParsed(_ignoreFileOption)) {
-      localIgnoreFile = results[_ignoreFileOption] as String?;
+    if (ignoreFileOverride != null) {
+      localIgnoreFile = ignoreFileOverride;
     }
 
     final validator = Validator(ruleOverrides: localRules);
@@ -185,11 +231,11 @@ Future<void> runApp(List<String> args) async {
       quiet: quiet,
     );
 
-    if (results.wasParsed(_generateBaselineFlag)) {
+    if (generateBaseline) {
       await _generateBaselineFile(result, localIgnoreFile, skillDir, skillDir);
     }
 
-    if (!results.wasParsed(_generateBaselineFlag)) {
+    if (!generateBaseline) {
       final String fullPath = p.absolute(skillDir.path);
       for (final ignore in skillIgnores) {
         if (!ignore.used) {
@@ -233,8 +279,8 @@ Future<void> runApp(List<String> args) async {
       }
     }
 
-    if (results.wasParsed(_ignoreFileOption)) {
-      localIgnoreFile = results[_ignoreFileOption] as String?;
+    if (ignoreFileOverride != null) {
+      localIgnoreFile = ignoreFileOverride;
     }
 
     final validator = Validator(ruleOverrides: localRules);
@@ -266,7 +312,7 @@ Future<void> runApp(List<String> args) async {
           quiet: quiet,
         );
 
-        if (results.wasParsed(_generateBaselineFlag)) {
+        if (generateBaseline) {
           await _generateBaselineFile(result, localIgnoreFile, rootDir, entity);
         }
 
@@ -279,7 +325,7 @@ Future<void> runApp(List<String> args) async {
       }
     }
 
-    if (!results.wasParsed(_generateBaselineFlag)) {
+    if (!generateBaseline) {
       for (final MapEntry<String, List<IgnoreEntry>> entry in ignoresMap.entries) {
         final String skillName = entry.key;
         for (final IgnoreEntry ignore in entry.value) {
@@ -314,11 +360,11 @@ Future<void> runApp(List<String> args) async {
     globalAnyFailed = true;
   }
 
-  if (results.wasParsed(_generateBaselineFlag)) {
+  if (generateBaseline) {
     globalAnyFailed = false;
   }
 
-  exitCode = globalAnyFailed ? 1 : 0;
+  return !globalAnyFailed;
 }
 
 @visibleForTesting

--- a/tool/generator/pubspec.lock
+++ b/tool/generator/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build_verify:
+    dependency: "direct dev"
+    description:
+      name: build_verify
+      sha256: "3b17b59b6d66f9d3e6014996f089902d56cec5760e051c353cc387b9da577652"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
   cli_config:
     dependency: transitive
     description:
@@ -89,6 +97,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
+  dart_skills_lint:
+    dependency: "direct dev"
+    description:
+      path: "../dart_skills_lint"
+      relative: true
+    source: path
+    version: "0.1.0"
   file:
     dependency: "direct main"
     description:
@@ -217,6 +232,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.0"
   lints:
     dependency: "direct dev"
     description:

--- a/tool/generator/pubspec.yaml
+++ b/tool/generator/pubspec.yaml
@@ -22,7 +22,10 @@ dependencies:
   yaml: ^3.1.2
 
 dev_dependencies:
+  build_verify: ^3.1.0
   coverage: ^1.15.0
+  dart_skills_lint:
+    path: ../dart_skills_lint
   lints: ^6.0.0
   test: ^1.25.6
 

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -7,29 +7,15 @@ import 'package:test/test.dart';
 
 void main() {
   test('Run skills linter', () async {
-    final config = Configuration(
-      directoryConfigs: [
-        DirectoryConfig(
-          path: '.agents/skills',
-          rules: {},
-          ignoreFile: '.agents/skills/ignore.json',
-        ),
-        DirectoryConfig(
-          path: '../../skills',
-          rules: {},
-          ignoreFile: '.agents/skills/flutter_skills_ignore.json',
-        ),
-      ],
-    );
-
-    // Triggers the linting checker with specific rules and paths.
-    await validateSkills(
-      skillDirPaths: ['.agents/skills', '../../skills'],
-      resolvedRules: {
-        'check-relative-paths': AnalysisSeverity.error,
-        'check-absolute-paths': AnalysisSeverity.error,
-      },
-      config: config,
+    expect(
+      await validateSkills(
+        skillDirPaths: ['../../skills'],
+        resolvedRules: {
+          'check-relative-paths': AnalysisSeverity.error,
+          'check-absolute-paths': AnalysisSeverity.error,
+        },
+      ),
+      isTrue,
     );
   });
 }

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -1,0 +1,35 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:dart_skills_lint/dart_skills_lint.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('Run skills linter', () async {
+    final config = Configuration(
+      directoryConfigs: [
+        DirectoryConfig(
+          path: '.agents/skills',
+          rules: {},
+          ignoreFile: '.agents/skills/ignore.json',
+        ),
+        DirectoryConfig(
+          path: '../../skills',
+          rules: {},
+          ignoreFile: '.agents/skills/flutter_skills_ignore.json',
+        ),
+      ],
+    );
+
+    // Triggers the linting checker with specific rules and paths.
+    await validateSkills(
+      skillDirPaths: ['.agents/skills', '../../skills'],
+      resolvedRules: {
+        'check-relative-paths': AnalysisSeverity.error,
+        'check-absolute-paths': AnalysisSeverity.error,
+      },
+      config: config,
+    );
+  });
+}


### PR DESCRIPTION
Refactor the `dart_skills_lint` package to support programmatic execution and integrates it into the `generator` package as a development dependency. 

Now there is a reusable `validateSkills` function, and key classes like `Validator`, `ValidationResult`, and `ValidationError` were exposed in the public API. 

As a side effect skills will be validated twice once with dart test in the generator package and again using dart run and the dart_skills_lint.yaml configuration from the github workflow. I think that is ok both as an end to end test and to show of both types of uses because it is fast. 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
