### PR TITLE
Add try catch around read directories and have new error conditions when files cannot be read, plus test

### DIFF
--- a/tool/dart_skills_lint/lib/src/validator.dart
+++ b/tool/dart_skills_lint/lib/src/validator.dart
@@ -101,14 +101,14 @@ class Validator {
           ruleId: skillFileInaccessible,
           file: skillMdFile.path,
           message: 'Failed to read $_skillFileName: $e',
-          severity: AnalysisSeverity.error));
+          severity: _getSeverity(skillFileInaccessible, AnalysisSeverity.error)));
       return ValidationResult(validationErrors: validationErrors);
     } catch (e) {
       validationErrors.add(ValidationError(
           ruleId: unexpectedError,
           file: skillMdFile.path,
           message: 'Unexpected error reading $_skillFileName: $e',
-          severity: AnalysisSeverity.error));
+          severity: _getSeverity(unexpectedError, AnalysisSeverity.error)));
       return ValidationResult(validationErrors: validationErrors);
     }
 

--- a/tool/dart_skills_lint/lib/src/validator.dart
+++ b/tool/dart_skills_lint/lib/src/validator.dart
@@ -64,6 +64,12 @@ class Validator {
   /// The name of the special check for missing files or directories.
   static const String pathDoesNotExist = 'path-does-not-exist';
 
+  /// The name of the special check for inaccessible files.
+  static const String skillFileInaccessible = 'skill-file-inaccessible';
+
+  /// The name of the special check for unexpected errors.
+  static const String unexpectedError = 'unexpected-error';
+
   final Map<String, AnalysisSeverity> _customSeverities;
   final List<SkillRule> _customRules;
   late final List<SkillRule> _rules;
@@ -87,7 +93,24 @@ class Validator {
     }
 
     final skillMdFile = File(p.join(dir.path, _skillFileName));
-    final String content = await skillMdFile.readAsString();
+    String content;
+    try {
+      content = await skillMdFile.readAsString();
+    } on FileSystemException catch (e) {
+      validationErrors.add(ValidationError(
+          ruleId: skillFileInaccessible,
+          file: skillMdFile.path,
+          message: 'Failed to read $_skillFileName: $e',
+          severity: AnalysisSeverity.error));
+      return ValidationResult(validationErrors: validationErrors);
+    } catch (e) {
+      validationErrors.add(ValidationError(
+          ruleId: unexpectedError,
+          file: skillMdFile.path,
+          message: 'Unexpected error reading $_skillFileName: $e',
+          severity: AnalysisSeverity.error));
+      return ValidationResult(validationErrors: validationErrors);
+    }
 
     YamlMap? parsedYaml;
     String? yamlParsingError;

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -2,12 +2,45 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:dart_skills_lint/src/models/analysis_severity.dart';
 import 'package:dart_skills_lint/src/validator.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
+
+class MockInaccessibleFile implements File {
+  MockInaccessibleFile(this._path);
+  final String _path;
+
+  @override
+  String get path => _path;
+
+  @override
+  bool existsSync() => true;
+
+  @override
+  Future<String> readAsString({Encoding encoding = utf8}) async {
+    throw FileSystemException('File is inaccessible', _path);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+base class TestIOOverrides extends IOOverrides {
+  TestIOOverrides(this.targetPath);
+  final String targetPath;
+
+  @override
+  File createFile(String path) {
+    if (path == targetPath) {
+      return MockInaccessibleFile(path);
+    }
+    return super.createFile(path);
+  }
+}
 
 void main() {
   group('Directory Structure Validation', () {
@@ -53,94 +86,58 @@ void main() {
     test('fails if SKILL.md cannot be read', () async {
       final skillDir = Directory(p.join(tempDir.path, 'test-skill-inaccessible'));
       await skillDir.create();
-      final file = File(p.join(skillDir.path, 'SKILL.md'));
-      await file.create();
+      final String filePath = p.join(skillDir.path, 'SKILL.md');
 
-      // Remove read permissions
-      ProcessResult result;
-      if (Platform.isWindows) {
-        // Remove all inherited permissions to make the file unreadable.
-        result = await Process.run('icacls', [file.path, '/inheritance:r']);
-      } else {
-        result = await Process.run('chmod', ['-r', file.path]);
-      }
+      final overrides = TestIOOverrides(filePath);
+      await IOOverrides.runWithIOOverrides(() async {
+        try {
+          final validator = Validator();
+          final ValidationResult validationResult = await validator.validate(skillDir);
 
-      if (result.exitCode != 0) {
-        fail('Failed to change file permissions: ${result.stderr}');
-      }
-
-      try {
-        final validator = Validator();
-        final ValidationResult validationResult = await validator.validate(skillDir);
-
-        // ignore: avoid_print
-        print(
-            'DEBUG errors: ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
-        expect(validationResult.isValid, isFalse);
-        expect(
-            validationResult.validationErrors
-                .any((e) => e.ruleId == Validator.skillFileInaccessible),
-            isTrue);
-      } catch (e, s) {
-        fail('Unexpected exception during validation: $e\n$s');
-      } finally {
-        // Restore permissions so cleanup can delete it
-        if (Platform.isWindows) {
-          await Process.run('icacls', [file.path, '/inheritance:e']);
-        } else {
-          await Process.run('chmod', ['+r', file.path]);
+          // ignore: avoid_print
+          print(
+              'DEBUG errors: ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
+          expect(validationResult.isValid, isFalse);
+          expect(
+              validationResult.validationErrors
+                  .any((e) => e.ruleId == Validator.skillFileInaccessible),
+              isTrue);
+        } catch (e, s) {
+          fail('Unexpected exception during validation: $e\n$s');
         }
-      }
+      }, overrides);
     });
 
     test('obeys skill-file-inaccessible severity override', () async {
       final skillDir = Directory(p.join(tempDir.path, 'test-skill-override'));
       await skillDir.create();
-      final file = File(p.join(skillDir.path, 'SKILL.md'));
-      await file.create();
+      final String filePath = p.join(skillDir.path, 'SKILL.md');
 
-      // Remove read permissions
-      ProcessResult result;
-      if (Platform.isWindows) {
-        // Remove all inherited permissions to make the file unreadable.
-        result = await Process.run('icacls', [file.path, '/inheritance:r']);
-      } else {
-        result = await Process.run('chmod', ['-r', file.path]);
-      }
+      final overrides = TestIOOverrides(filePath);
+      await IOOverrides.runWithIOOverrides(() async {
+        try {
+          final validator = Validator(
+            ruleOverrides: {
+              Validator.skillFileInaccessible: AnalysisSeverity.warning,
+            },
+          );
+          final ValidationResult validationResult = await validator.validate(skillDir);
 
-      if (result.exitCode != 0) {
-        fail('Failed to change file permissions: ${result.stderr}');
-      }
-
-      try {
-        final validator = Validator(
-          ruleOverrides: {
-            Validator.skillFileInaccessible: AnalysisSeverity.warning,
-          },
-        );
-        final ValidationResult validationResult = await validator.validate(skillDir);
-
-        // ignore: avoid_print
-        print(
-            'DEBUG errors (override): ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
-        expect(validationResult.isValid, isTrue);
-        expect(
-            validationResult.validationErrors.any(
-              (e) =>
-                  e.ruleId == Validator.skillFileInaccessible &&
-                  e.severity == AnalysisSeverity.warning,
-            ),
-            isTrue);
-      } catch (e, s) {
-        fail('Unexpected exception during validation: $e\n$s');
-      } finally {
-        // Restore permissions so cleanup can delete it
-        if (Platform.isWindows) {
-          await Process.run('icacls', [file.path, '/inheritance:e']);
-        } else {
-          await Process.run('chmod', ['+r', file.path]);
+          // ignore: avoid_print
+          print(
+              'DEBUG errors (override): ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
+          expect(validationResult.isValid, isTrue);
+          expect(
+              validationResult.validationErrors.any(
+                (e) =>
+                    e.ruleId == Validator.skillFileInaccessible &&
+                    e.severity == AnalysisSeverity.warning,
+              ),
+              isTrue);
+        } catch (e, s) {
+          fail('Unexpected exception during validation: $e\n$s');
         }
-      }
+      }, overrides);
     });
 
     test('passes if directory exists and contains SKILL.md', () async {

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:dart_skills_lint/src/models/analysis_severity.dart';
 import 'package:dart_skills_lint/src/validator.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
@@ -58,9 +59,8 @@ void main() {
       // Remove read permissions
       ProcessResult result;
       if (Platform.isWindows) {
-        // Use SID *S-1-1-0 (Everyone) to support non-English Windows locales.
-        result =
-            await Process.run('icacls', [file.path, '/inheritance:r', '/deny', '*S-1-1-0:(R)']);
+        // Remove all inherited permissions to make the file unreadable.
+        result = await Process.run('icacls', [file.path, '/inheritance:r']);
       } else {
         result = await Process.run('chmod', ['-r', file.path]);
       }
@@ -77,6 +77,53 @@ void main() {
         expect(
             validationResult.validationErrors
                 .any((e) => e.ruleId == Validator.skillFileInaccessible),
+            isTrue);
+      } catch (e, s) {
+        fail('Unexpected exception during validation: $e\n$s');
+      } finally {
+        // Restore permissions so cleanup can delete it
+        if (Platform.isWindows) {
+          await Process.run('icacls', [file.path, '/inheritance:e']);
+        } else {
+          await Process.run('chmod', ['+r', file.path]);
+        }
+      }
+    });
+
+    test('obeys skill-file-inaccessible severity override', () async {
+      final skillDir = Directory(p.join(tempDir.path, 'test-skill-override'));
+      await skillDir.create();
+      final file = File(p.join(skillDir.path, 'SKILL.md'));
+      await file.create();
+
+      // Remove read permissions
+      ProcessResult result;
+      if (Platform.isWindows) {
+        // Remove all inherited permissions to make the file unreadable.
+        result = await Process.run('icacls', [file.path, '/inheritance:r']);
+      } else {
+        result = await Process.run('chmod', ['-r', file.path]);
+      }
+
+      if (result.exitCode != 0) {
+        fail('Failed to change file permissions: ${result.stderr}');
+      }
+
+      try {
+        final validator = Validator(
+          ruleOverrides: {
+            Validator.skillFileInaccessible: AnalysisSeverity.warning,
+          },
+        );
+        final ValidationResult validationResult = await validator.validate(skillDir);
+
+        expect(validationResult.isValid, isTrue);
+        expect(
+            validationResult.validationErrors.any(
+              (e) =>
+                  e.ruleId == Validator.skillFileInaccessible &&
+                  e.severity == AnalysisSeverity.warning,
+            ),
             isTrue);
       } catch (e, s) {
         fail('Unexpected exception during validation: $e\n$s');

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -73,6 +73,9 @@ void main() {
         final validator = Validator();
         final ValidationResult validationResult = await validator.validate(skillDir);
 
+        // ignore: avoid_print
+        print(
+            'DEBUG errors: ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
         expect(validationResult.isValid, isFalse);
         expect(
             validationResult.validationErrors
@@ -117,6 +120,9 @@ void main() {
         );
         final ValidationResult validationResult = await validator.validate(skillDir);
 
+        // ignore: avoid_print
+        print(
+            'DEBUG errors (override): ${validationResult.validationErrors.map((e) => "${e.ruleId}: ${e.message}").toList()}');
         expect(validationResult.isValid, isTrue);
         expect(
             validationResult.validationErrors.any(

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -58,7 +58,8 @@ void main() {
       // Remove read permissions
       ProcessResult result;
       if (Platform.isWindows) {
-        result = await Process.run('icacls', [file.path, '/deny', 'Everyone:(R)']);
+        // Use SID *S-1-1-0 (Everyone) to support non-English Windows locales.
+        result = await Process.run('icacls', [file.path, '/inheritance:r', '/deny', '*S-1-1-0:(R)']);
       } else {
         result = await Process.run('chmod', ['-r', file.path]);
       }
@@ -67,19 +68,23 @@ void main() {
         fail('Failed to change file permissions: ${result.stderr}');
       }
 
-      final validator = Validator();
-      final ValidationResult validationResult = await validator.validate(skillDir);
+      try {
+        final validator = Validator();
+        final ValidationResult validationResult = await validator.validate(skillDir);
 
-      expect(validationResult.isValid, isFalse);
-      expect(
-          validationResult.validationErrors.any((e) => e.ruleId == Validator.skillFileInaccessible),
-          isTrue);
-
-      // Restore permissions so cleanup can delete it
-      if (Platform.isWindows) {
-        await Process.run('icacls', [file.path, '/remove:d', 'Everyone']);
-      } else {
-        await Process.run('chmod', ['+r', file.path]);
+        expect(validationResult.isValid, isFalse);
+        expect(
+            validationResult.validationErrors.any((e) => e.ruleId == Validator.skillFileInaccessible),
+            isTrue);
+      } catch (e, s) {
+        fail('Unexpected exception during validation: $e\n$s');
+      } finally {
+        // Restore permissions so cleanup can delete it
+        if (Platform.isWindows) {
+          await Process.run('icacls', [file.path, '/inheritance:e']);
+        } else {
+          await Process.run('chmod', ['+r', file.path]);
+        }
       }
     });
 

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -59,7 +59,8 @@ void main() {
       ProcessResult result;
       if (Platform.isWindows) {
         // Use SID *S-1-1-0 (Everyone) to support non-English Windows locales.
-        result = await Process.run('icacls', [file.path, '/inheritance:r', '/deny', '*S-1-1-0:(R)']);
+        result =
+            await Process.run('icacls', [file.path, '/inheritance:r', '/deny', '*S-1-1-0:(R)']);
       } else {
         result = await Process.run('chmod', ['-r', file.path]);
       }
@@ -74,7 +75,8 @@ void main() {
 
         expect(validationResult.isValid, isFalse);
         expect(
-            validationResult.validationErrors.any((e) => e.ruleId == Validator.skillFileInaccessible),
+            validationResult.validationErrors
+                .any((e) => e.ruleId == Validator.skillFileInaccessible),
             isTrue);
       } catch (e, s) {
         fail('Unexpected exception during validation: $e\n$s');

--- a/tool/dart_skills_lint/test/directory_structure_test.dart
+++ b/tool/dart_skills_lint/test/directory_structure_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:dart_skills_lint/src/validator.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 void main() {
@@ -48,10 +49,44 @@ void main() {
       expect(result.errors, contains(contains('SKILL.md is missing')));
     });
 
-    test('passes if directory exists and contains SKILL.md', () async {
-      final skillDir = Directory('${tempDir.path}/test-skill');
+    test('fails if SKILL.md cannot be read', () async {
+      final skillDir = Directory(p.join(tempDir.path, 'test-skill-inaccessible'));
       await skillDir.create();
-      await File('${skillDir.path}/SKILL.md').writeAsString('''
+      final file = File(p.join(skillDir.path, 'SKILL.md'));
+      await file.create();
+
+      // Remove read permissions
+      ProcessResult result;
+      if (Platform.isWindows) {
+        result = await Process.run('icacls', [file.path, '/deny', 'Everyone:(R)']);
+      } else {
+        result = await Process.run('chmod', ['-r', file.path]);
+      }
+
+      if (result.exitCode != 0) {
+        fail('Failed to change file permissions: ${result.stderr}');
+      }
+
+      final validator = Validator();
+      final ValidationResult validationResult = await validator.validate(skillDir);
+
+      expect(validationResult.isValid, isFalse);
+      expect(
+          validationResult.validationErrors.any((e) => e.ruleId == Validator.skillFileInaccessible),
+          isTrue);
+
+      // Restore permissions so cleanup can delete it
+      if (Platform.isWindows) {
+        await Process.run('icacls', [file.path, '/remove:d', 'Everyone']);
+      } else {
+        await Process.run('chmod', ['+r', file.path]);
+      }
+    });
+
+    test('passes if directory exists and contains SKILL.md', () async {
+      final skillDir = Directory(p.join(tempDir.path, 'test-skill'));
+      await skillDir.create();
+      await File(p.join(skillDir.path, 'SKILL.md')).writeAsString('''
 ---
 name: test-skill
 description: A test skill


### PR DESCRIPTION
This better handles when skills are symlinked to directories that may not be accessible 

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#overview
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[test-exempt]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
