### PR TITLE
Fix stray brace in flutter-use-http-package SKILL sample

### DIFF
--- a/skills/flutter-use-http-package/SKILL.md
+++ b/skills/flutter-use-http-package/SKILL.md
@@ -107,7 +107,6 @@ Future<List<Photo>> fetchPhotos() async {
     throw Exception('Failed to load photos. Status: ${response.statusCode}');
   }
 }
-}
 
 // 3. Strongly typed model
 class Photo {


### PR DESCRIPTION
## Summary

Removes an extra closing brace in the Dart code sample in `skills/flutter-use-http-package/SKILL.md`. The `fetchPhotos()` function already ends at the preceding `}`; the following lone `}` broke the sample's brace balance.

## Changes

- Delete one stray `}` after `fetchPhotos()` in the fenced example.

## Notes

- Minimal, documentation-only change.
- Happy to adjust wording or rebase if maintainers prefer following CONTRIBUTING / issue-first workflow.
