### PR TITLE
Add Gas Town runtime artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,11 @@ coverage/
 
 # Validation output from the validate-skill command
 validation/
+
+# Gas Town (added by gt)
+.runtime/
+.logs/
+__pycache__/
+state.json
+CLAUDE.md
+CLAUDE.local.md


### PR DESCRIPTION
## Summary
- Ignore `.runtime/`, `.logs/`, `__pycache__/`, `state.json`, and `CLAUDE.md` / `CLAUDE.local.md` so Gas Town workspace state doesn't leak into commits when contributors work on this repo from inside a Gas Town rig.
