### PR TITLE
Add --yes flag to skills add command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The `--agent universal` flag puts it in the standard `.agents/skills`
 folder that most agents use.
 
 ```bash
-npx skills add flutter/skills --skill '*' --agent universal
+npx skills add flutter/skills --skill '*' --agent universal --yes
 ```
 
 ## Updating Skills


### PR DESCRIPTION
This PR updates the installation command in the README by adding the --yes flag to the npx skills add command.
What Changed
Before:
npx skills add flutter/skills --skill '*' --agent universal
After:
npx skills add flutter/skills --skill '*' --agent universal --yes
Why
The --yes flag enables non-interactive execution by automatically confirming prompts during installation. This improves automation support and provides a smoother experience for users running the command in CI/CD pipelines, scripts, or headless environments.
Fixes


Fixes issue where the installation command pauses for manual confirmation during automated execution.



Pre-launch Checklist


 I read the Contributor Guide and followed the process outlined there for submitting PRs.


 I read the Tree Hygiene wiki page, which explains my responsibilities.


 I read the Flutter Style Guide recently, and have followed its advice.


 I signed the CLA.


 I listed at least one issue that this PR fixes in the description above.


 I updated/added relevant documentation (doc comments with ///).


 This PR is test-exempt (documentation-only change).


 All existing and new tests are passing.

