### PR TITLE
Add Claude Code support alongside .agents config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@
 .dart_tool/
 pubspec.lock
 
-# Claude Code
-.claude/
+# Claude Code — commit shared config (settings.json, skills/, agents/, commands/),
+# but keep personal/local overrides out of version control.
+**/.claude/settings.local.json
 
 # IntelliJ
 *.iml

--- a/tool/dart_skills_lint/.claude/skills
+++ b/tool/dart_skills_lint/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills


### PR DESCRIPTION
## Summary
- Configures `tool/dart_skills_lint` to work with Claude Code in parallel with the existing Google `.agents/` setup, without duplicating content.
- Adds a `.claude/skills` symlink pointing at the existing `.agents/skills`, so the dart skills load in Claude from a single source of truth (the `SKILL.md` format is shared between both systems).

Does not setup hooks because the hooks scripts do not support claude style inputs or outputs. 