### PR TITLE
lint: add --config CLI argument for custom config path

### DIFF
--- a/tool/dart_skills_lint/lib/src/entry_point.dart
+++ b/tool/dart_skills_lint/lib/src/entry_point.dart
@@ -32,6 +32,7 @@ const _fixFlag = 'fix';
 const _dryRunFlag = 'dry-run';
 const _fixApplyFlag = 'fix-apply';
 const _allowMisconfiguredKeysFlag = 'allow-misconfigured-keys';
+const _configOption = 'config';
 
 /// User-visible deprecation notice for the legacy `--fix-apply` alias.
 ///
@@ -228,6 +229,11 @@ ArgParser _createArgParser(String helpFlag) {
       negatable: false,
       hide: true,
       help: 'Allow misconfigured keys in dart_skills_lint.yaml.',
+    )
+    ..addOption(
+      _configOption,
+      abbr: 'c',
+      help: 'Path to a custom configuration file (defaults to dart_skills_lint.yaml).',
     );
 
   return parser;
@@ -239,7 +245,16 @@ Future<Configuration?> _loadConfig(ArgResults results) async {
   if (ignoreConfig) {
     config = Configuration();
   } else {
-    config = await ConfigParser.loadConfig();
+    try {
+      final configPath = results[_configOption] as String?;
+      config = await ConfigParser.loadConfig(path: configPath);
+    } on FileSystemException catch (e) {
+      _log.severe('Error: ${e.message} (${e.path})');
+      return null;
+    } catch (e) {
+      _log.severe('Error loading configuration: $e');
+      return null;
+    }
   }
   if (ignoreConfig && !(results[_quietFlag] as bool)) {
     _log.info('Ignoring configuration file due to $_ignoreConfigFlag flag');

--- a/tool/dart_skills_lint/test/config_file_test.dart
+++ b/tool/dart_skills_lint/test/config_file_test.dart
@@ -377,5 +377,56 @@ dart_skills_lint:
       );
       await process.shouldExit(0);
     });
+
+    test('obeys custom configuration file path via --config', () async {
+      final Directory skillDir = await Directory('${tempDir.path}/test-skill').create();
+      await File('${skillDir.path}/SKILL.md').writeAsString('''
+---
+name: test-skill
+description: A test skill
+---
+[broken](missing.md)''');
+
+      await File('${tempDir.path}/custom_config.yaml').writeAsString('''
+dart_skills_lint:
+  rules:
+    check-relative-paths: disabled
+''');
+
+      final TestProcess process = await TestProcess.start('dart', [
+        p.normalize(p.absolute('bin/cli.dart')),
+        '-s',
+        'test-skill',
+        '--config',
+        'custom_config.yaml',
+      ], workingDirectory: tempDir.path);
+
+      final List<String> stdout = await process.stdout.rest.toList();
+      expect(stdout.join('\n'), contains('Skill is valid.'));
+      await process.shouldExit(0);
+    });
+
+    test('exits with 1 and prints error message if --config points to non-existent file', () async {
+      await Directory('${tempDir.path}/test-skill').create();
+      await File('${tempDir.path}/test-skill/SKILL.md').writeAsString('''
+---
+name: test-skill
+description: A test skill
+---
+Body''');
+
+      final TestProcess process = await TestProcess.start('dart', [
+        p.normalize(p.absolute('bin/cli.dart')),
+        '-s',
+        'test-skill',
+        '--config',
+        'non_existent_config.yaml',
+      ], workingDirectory: tempDir.path);
+
+      final List<String> stderr = await process.stderr.rest.toList();
+      expect(stderr.join('\n'), contains('Configuration file not found'));
+      expect(stderr.join('\n'), contains('non_existent_config.yaml'));
+      await process.shouldExit(1);
+    });
   });
 }

--- a/tool/dart_skills_lint/test/config_file_test.dart
+++ b/tool/dart_skills_lint/test/config_file_test.dart
@@ -428,5 +428,33 @@ Body''');
       expect(stderr.join('\n'), contains('non_existent_config.yaml'));
       await process.shouldExit(1);
     });
+
+    test('ignores config when both --config and --ignore-config are passed', () async {
+      final Directory skillDir = await Directory('${tempDir.path}/TEST-SKILL').create();
+      await File('${skillDir.path}/SKILL.md').writeAsString('''
+---
+name: TEST-SKILL
+description: A test skill
+license: MIT
+---
+Body''');
+
+      await File('${tempDir.path}/custom_config.yaml').writeAsString('''
+dart_skills_lint:
+  rules:
+    invalid-skill-name: disabled
+''');
+
+      final TestProcess process = await TestProcess.start('dart', [
+        p.normalize(p.absolute('bin/cli.dart')),
+        '-s',
+        'TEST-SKILL',
+        '--config',
+        'custom_config.yaml',
+        '--ignore-config',
+      ], workingDirectory: tempDir.path);
+
+      await process.shouldExit(1);
+    });
   });
 }


### PR DESCRIPTION
Adds the `-c` / `--config` CLI argument to `dart_skills_lint` to support custom configuration file paths. Includes precedence logic ensuring `--ignore-config` overrides `--config`, error handling for missing/malformed configuration files, and complete unit/integration tests.