### PR TITLE
Fix dart_hooks.yaml example keys so hooks are actually enabled (#150)

### DIFF
--- a/dart_hooks.yaml
+++ b/dart_hooks.yaml
@@ -1,2 +1,2 @@
-agent_dart_format.dart: true
-agent_dart_analyze.dart: true
+DartFormatHook: true
+DartAnalyzeHook: true

--- a/tool/dart_hooks.yaml
+++ b/tool/dart_hooks.yaml
@@ -1,2 +1,2 @@
-agent_dart_format.dart: true
-agent_dart_analyze.dart: true
+DartFormatHook: true
+DartAnalyzeHook: true

--- a/tool/dart_hooks/dart_hooks.yaml
+++ b/tool/dart_hooks/dart_hooks.yaml
@@ -1,2 +1,2 @@
-agent_dart_format.dart: true
-agent_dart_analyze.dart: true
+DartFormatHook: true
+DartAnalyzeHook: true

--- a/tool/dart_hooks/lib/src/base_hook.dart
+++ b/tool/dart_hooks/lib/src/base_hook.dart
@@ -63,7 +63,7 @@ abstract class BaseHook {
       final dynamic yaml = loadYaml(configContent);
       if (yaml is Map) {
         if (!yaml.containsKey(configKey)) {
-          final String foundKeys = (yaml as Map).keys.join(', ');
+          final String foundKeys = yaml.keys.join(', ');
           await logToFile(
             'Hook $hookName is disabled (key "$configKey" is missing in configuration). '
             'Found keys: [$foundKeys]. Did you mean to enable it with "$configKey: true"?',

--- a/tool/dart_hooks/lib/src/base_hook.dart
+++ b/tool/dart_hooks/lib/src/base_hook.dart
@@ -63,7 +63,7 @@ abstract class BaseHook {
       final dynamic yaml = loadYaml(configContent);
       if (yaml is Map) {
         if (!yaml.containsKey(configKey)) {
-          final String foundKeys = yaml.keys.join(', ');
+          final String foundKeys = (yaml as Map).keys.join(', ');
           await logToFile(
             'Hook $hookName is disabled (key "$configKey" is missing in configuration). '
             'Found keys: [$foundKeys]. Did you mean to enable it with "$configKey: true"?',

--- a/tool/dart_hooks/lib/src/base_hook.dart
+++ b/tool/dart_hooks/lib/src/base_hook.dart
@@ -63,8 +63,10 @@ abstract class BaseHook {
       final dynamic yaml = loadYaml(configContent);
       if (yaml is Map) {
         if (!yaml.containsKey(configKey)) {
+          final String foundKeys = yaml.keys.join(', ');
           await logToFile(
-            'Hook $hookName is disabled (key "$configKey" is missing in configuration).',
+            'Hook $hookName is disabled (key "$configKey" is missing in configuration). '
+            'Found keys: [$foundKeys]. Did you mean to enable it with "$configKey: true"?',
           );
           printStdout(jsonEncode({'decision': 'stop'}));
           onExit(0);

--- a/tool/dart_hooks/test/base_hook_test.dart
+++ b/tool/dart_hooks/test/base_hook_test.dart
@@ -242,6 +242,10 @@ void main() {
           loggedMessages.first,
           contains('is disabled (key "test_hook" is missing in configuration)'),
         );
+        // Verify the warning surfaces the keys that were found so a typo'd or
+        // legacy key (e.g. a script filename) does not silently disable a hook.
+        expect(loggedMessages.first, contains('Found keys: [other_hook].'));
+        expect(loggedMessages.first, contains('"test_hook: true"'));
       });
 
       test('Disabled setting logs disabled', () async {

--- a/tool/dart_skills_lint/dart_hooks.yaml
+++ b/tool/dart_skills_lint/dart_hooks.yaml
@@ -1,2 +1,2 @@
-agent_dart_format.dart: true
-agent_dart_analyze.dart: true
+DartFormatHook: true
+DartAnalyzeHook: true


### PR DESCRIPTION
## Summary

Fixes #150.

The example `dart_hooks.yaml` files committed in #148 used the script filenames as keys (`agent_dart_format.dart` / `agent_dart_analyze.dart`). `BaseHook.run()` gates each hook on its `configKey`, which is the **class name** (`DartFormatHook` / `DartAnalyzeHook`). Because those keys never matched, copying any committed example left both hooks silently disabled — contradicting the README, which documents the correct keys.

## Changes

- Update all four committed `dart_hooks.yaml` files to the class-name keys the code reads and the README documents:
  - `dart_hooks.yaml`
  - `tool/dart_hooks.yaml`
  - `tool/dart_hooks/dart_hooks.yaml`
  - `tool/dart_skills_lint/dart_hooks.yaml` (a fourth file with the same bug, not listed in the issue)

  ```yaml
  DartFormatHook: true
  DartAnalyzeHook: true
  ```

- Improve the diagnostic (the issue's optional suggestion). When the expected key is missing, the log now lists the keys that *were* found and suggests the correct one, so a typo'd or legacy key no longer disables a hook with an opaque message:

  > Hook dart format is disabled (key "DartFormatHook" is missing in configuration). Found keys: [agent_dart_format.dart, agent_dart_analyze.dart]. Did you mean to enable it with "DartFormatHook: true"?

  This is scoped to each hook's own key (no shared-registry refactor) since the message points straight at the fix. The README troubleshooting section quotes only the unchanged message prefix, so it stays accurate.

## Verification

- `dart test` — all pass (extended the existing "missing config key" test to assert the found-keys diagnostic)
- `dart format --set-exit-if-changed` — clean
- `dart analyze` — no issues