### PR TITLE
Enforce BSD copyright headers in dart_skills_lint Dart files

### DIFF
--- a/tool/dart_skills_lint/bin/cli.dart
+++ b/tool/dart_skills_lint/bin/cli.dart
@@ -1,5 +1,4 @@
 #!/usr/bin/env dart
-
 // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/tool/dart_skills_lint/bin/cli.dart
+++ b/tool/dart_skills_lint/bin/cli.dart
@@ -1,4 +1,5 @@
 #!/usr/bin/env dart
+
 // Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/tool/dart_skills_lint/lib/src/cutoff_excerpt.dart
+++ b/tool/dart_skills_lint/lib/src/cutoff_excerpt.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 // Shared helper for "field is N characters; max is M" diagnostics that
 // also show a |HERE| cutoff excerpt so the author can see exactly
 // where the value went over.

--- a/tool/dart_skills_lint/lib/src/levenshtein.dart
+++ b/tool/dart_skills_lint/lib/src/levenshtein.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:math' as math;
 
 /// Plain Levenshtein edit distance over runes. O(n*m) time, O(m) space.

--- a/tool/dart_skills_lint/lib/src/models/skill_context.dart
+++ b/tool/dart_skills_lint/lib/src/models/skill_context.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 

--- a/tool/dart_skills_lint/lib/src/models/skill_rule.dart
+++ b/tool/dart_skills_lint/lib/src/models/skill_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'analysis_severity.dart';
 import 'skill_context.dart';
 import 'validation_error.dart';

--- a/tool/dart_skills_lint/lib/src/rules/absolute_paths_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/absolute_paths_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:path/path.dart';
 import '../fixable_rule.dart';

--- a/tool/dart_skills_lint/lib/src/rules/description_length_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/description_length_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:yaml/yaml.dart';
 import '../cutoff_excerpt.dart';
 import '../models/analysis_severity.dart';

--- a/tool/dart_skills_lint/lib/src/rules/disallowed_field_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/disallowed_field_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:yaml/yaml.dart';
 import '../models/analysis_severity.dart';
 import '../models/skill_context.dart';

--- a/tool/dart_skills_lint/lib/src/rules/name_format_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/name_format_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';

--- a/tool/dart_skills_lint/lib/src/rules/relative_paths_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/relative_paths_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 import 'package:meta/meta.dart';
 import 'package:path/path.dart';

--- a/tool/dart_skills_lint/lib/src/rules/valid_yaml_metadata_rule.dart
+++ b/tool/dart_skills_lint/lib/src/rules/valid_yaml_metadata_rule.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:yaml/yaml.dart';
 import '../cutoff_excerpt.dart';
 import '../models/analysis_severity.dart';

--- a/tool/dart_skills_lint/test/copyright_header_test.dart
+++ b/tool/dart_skills_lint/test/copyright_header_test.dart
@@ -1,0 +1,62 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+/// Pins the BSD copyright header to every Dart source file in the package.
+///
+/// Every `.dart` file in `lib/`, `bin/`, and `test/` must begin with the
+/// standard three-line copyright block. The year is not pinned — any four-digit
+/// year is accepted — but the rest of the text is matched exactly.
+void main() {
+  test('every Dart file has a BSD copyright header', () {
+    final String packageRoot = p.normalize(p.absolute('.'));
+    final List<String> missing = [];
+
+    for (final dir in ['bin', 'lib', 'test']) {
+      final source = Directory(p.join(packageRoot, dir));
+      if (!source.existsSync()) {
+        continue;
+      }
+      for (final FileSystemEntity entity in source.listSync(recursive: true)) {
+        if (entity is File && entity.path.endsWith('.dart')) {
+          final String content = entity.readAsStringSync();
+          if (!_hasCopyrightHeader(content)) {
+            missing.add(p.relative(entity.path, from: packageRoot));
+          }
+        }
+      }
+    }
+
+    expect(
+      missing,
+      isEmpty,
+      reason:
+          'The following Dart files are missing the BSD copyright header:\n'
+          '  ${missing.join('\n  ')}\n\n'
+          'Add the following block as the first three lines of each file:\n'
+          '  // Copyright (c) <year>, the Dart project authors.  Please see the AUTHORS file\n'
+          '  // for details. All rights reserved. Use of this source code is governed by a\n'
+          '  // BSD-style license that can be found in the LICENSE file.',
+    );
+  });
+}
+
+final RegExp _copyrightPattern = RegExp(
+  r'^// Copyright \(c\) \d{4}, the Dart project authors\. {2}Please see the AUTHORS file\n'
+  r'// for details\. All rights reserved\. Use of this source code is governed by a\n'
+  r'// BSD-style license that can be found in the LICENSE file\.',
+);
+
+bool _hasCopyrightHeader(String content) {
+  // Allow an optional shebang line (and any following blank lines) before the
+  // copyright header.
+  final String checkContent = content.startsWith('#!')
+      ? content.substring(content.indexOf('\n') + 1).replaceFirst(RegExp(r'^\n*'), '')
+      : content;
+  return _copyrightPattern.hasMatch(checkContent);
+}

--- a/tool/dart_skills_lint/test/copyright_header_test.dart
+++ b/tool/dart_skills_lint/test/copyright_header_test.dart
@@ -12,12 +12,25 @@ import 'package:test/test.dart';
 /// Every `.dart` file in `lib/`, `bin/`, and `test/` must begin with the
 /// standard three-line copyright block. The year is not pinned — any four-digit
 /// year is accepted — but the rest of the text is matched exactly.
+
+/// The canonical copyright header. Used in both the check and the error message
+/// so the two never drift apart.
+const String _copyrightHeader =
+    '// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file\n'
+    '// for details. All rights reserved. Use of this source code is governed by a\n'
+    '// BSD-style license that can be found in the LICENSE file.';
+
+/// Directories to scan for Dart source files, relative to the package root
+/// (i.e. the directory that contains `pubspec.yaml`, which is also the working
+/// directory when `dart test` is invoked from the package).
+const Set<String> _sourceDirs = {'bin', 'lib', 'test'};
+
 void main() {
   test('every Dart file has a BSD copyright header', () {
     final String packageRoot = p.normalize(p.absolute('.'));
     final List<String> missing = [];
 
-    for (final dir in ['bin', 'lib', 'test']) {
+    for (final String dir in _sourceDirs) {
       final source = Directory(p.join(packageRoot, dir));
       if (!source.existsSync()) {
         continue;
@@ -39,9 +52,7 @@ void main() {
           'The following Dart files are missing the BSD copyright header:\n'
           '  ${missing.join('\n  ')}\n\n'
           'Add the following block as the first three lines of each file:\n'
-          '  // Copyright (c) <year>, the Dart project authors.  Please see the AUTHORS file\n'
-          '  // for details. All rights reserved. Use of this source code is governed by a\n'
-          '  // BSD-style license that can be found in the LICENSE file.',
+          '$_copyrightHeader',
     );
   });
 }
@@ -53,10 +64,13 @@ final RegExp _copyrightPattern = RegExp(
 );
 
 bool _hasCopyrightHeader(String content) {
+  // Normalize Windows line endings so the regex works on files checked out
+  // with core.autocrlf enabled.
+  final String normalized = content.replaceAll('\r\n', '\n');
   // Allow an optional shebang line (and any following blank lines) before the
   // copyright header.
-  final String checkContent = content.startsWith('#!')
-      ? content.substring(content.indexOf('\n') + 1).replaceFirst(RegExp(r'^\n*'), '')
-      : content;
+  final String checkContent = normalized.startsWith('#!')
+      ? normalized.substring(normalized.indexOf('\n') + 1).replaceFirst(RegExp(r'^\n*'), '')
+      : normalized;
   return _copyrightPattern.hasMatch(checkContent);
 }

--- a/tool/dart_skills_lint/test/custom_rule_test.dart
+++ b/tool/dart_skills_lint/test/custom_rule_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 import 'package:dart_skills_lint/dart_skills_lint.dart';

--- a/tool/dart_skills_lint/test/dart_skills_lint_skills_test.dart
+++ b/tool/dart_skills_lint/test/dart_skills_lint_skills_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:io';
 import 'package:dart_skills_lint/dart_skills_lint.dart';

--- a/tool/dart_skills_lint/test/rule_naming_test.dart
+++ b/tool/dart_skills_lint/test/rule_naming_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:dart_skills_lint/src/rules/absolute_paths_rule.dart';
 import 'package:dart_skills_lint/src/rules/description_length_rule.dart';

--- a/tool/dart_skills_lint/test/tracked_skills_publishing_test.dart
+++ b/tool/dart_skills_lint/test/tracked_skills_publishing_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:dart_skills_lint/src/config_parser.dart';


### PR DESCRIPTION
## Summary

- Adds `test/copyright_header_test.dart` which scans every `.dart` file under `bin/`, `lib/`, and `test/` and fails if any is missing the three-line BSD copyright block (year is not pinned; shebang files are handled correctly)
- Backfills the 15 Dart source files that were missing the header

Closes #160.
