### PR TITLE
Rename to flutter/agent-plugins

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,20 @@
-# Contributing to Flutter Skills
+# Contributing to Flutter Agent Plugins
 
 ## Note on contributions
 
-We are not yet open for direct contributions as we are still actively working on publishing a larger set of skills. Your experience using these skills is important to us. If you find a bug or have an idea for a skill you'd like to see added, please [file an issue][issue] or request following the insturctions below. 
+We are not yet open for direct contributions as we are still actively working on publishing a larger set of plugins and skills. Your experience using these plugins is important to us. If you find a bug or have an idea for a plugin or skill you'd like to see added, please [file an issue][issue] or request following the instructions below. 
 
 We appreciate your feedback!
 
-## Providing Feedback on an existing skill
+## Providing Feedback on an existing plugin or skill
 [File an issue][issue] and let us know:
 1. What language model are you using? (Gemini 3.1 Flash, Claude Sonnet 4.6, etc)
 2. What agent harness are you using? (Antigravity, Gemini CLI, Claude Code, Cursor)
-3. Logs that show what prompt you used and steps the agent took to complete the task (Such as what skills it chose to use, MCP tools it used, etc).
+3. Logs that show what prompt you used and steps the agent took to complete the task (such as what plugins/skills it chose to use, MCP tools it used, etc).
 
-## Requesting a skill
-First check if its on the [list of skills we plan to work on next][next skills] and feel free to comment if you'd like us to prioritize differently.
-If not [file an issue][issue] and we will prioritize it.
+## Requesting a plugin or skill
+First check if it is on the [list of plugins/skills we plan to work on next][next plugins/skills] and feel free to comment if you'd like us to prioritize differently.
+If not, [file an issue][issue] and we will prioritize it.
 
 ## Issue triage
 
@@ -27,10 +27,10 @@ We regularly triage issues by looking at newly filed issues and determining what
 
 At the end of a triage session, the untriaged issue list should be as close to empty as possible.
 
-[issue]: https://github.com/flutter/skills/issues
-[next skills]: https://github.com/flutter/skills/issues/88
-[untriaged_list]: https://github.com/flutter/skills/issues?q=is%3Aissue+state%3Aopen+-label%3Atriaged
-[P0]: https://github.com/flutter/skills/labels?q=P0
-[P1]: https://github.com/flutter/skills/labels?q=P1
-[P2]: https://github.com/flutter/skills/labels?q=P2
-[P3]: https://github.com/flutter/skills/labels?q=P3
+[issue]: https://github.com/flutter/agent-plugins/issues
+[next plugins/skills]: https://github.com/flutter/agent-plugins/issues/88
+[untriaged_list]: https://github.com/flutter/agent-plugins/issues?q=is%3Aissue+state%3Aopen+-label%3Atriaged
+[P0]: https://github.com/flutter/agent-plugins/labels?q=P0
+[P1]: https://github.com/flutter/agent-plugins/labels?q=P1
+[P2]: https://github.com/flutter/agent-plugins/labels?q=P2
+[P3]: https://github.com/flutter/agent-plugins/labels?q=P3

--- a/README.md
+++ b/README.md
@@ -1,23 +1,24 @@
-# Flutter Agent Skills
+# Flutter Agent Plugins
 
-Agent skills for Flutter, maintained by the Flutter team.
-A collection of skills providing tailored instructions for happy path Flutter app development workflows. By giving the agent actual domain expertise and repeatable workflows, you drastically reduce mistakes and ensure agents reliably complete the task following best practices.
+Agent plugins for Flutter, maintained by the Flutter team.
 
-Skills are essentially simple folders of files that can be seen as complementary to MCP, where MCP gives an agent access to specialized tools and a Skill teaches the agent “how” to use tools for a specific task.
+A collection of plugins designed to extend AI agent capabilities for Flutter development. These plugins bundle together skills, subagents, rules, and configurations to provide tailored workflows and instructions for happy path Flutter development. By giving the agent domain expertise and repeatable workflows, you drastically reduce mistakes and ensure agents reliably complete tasks following best practices.
 
-You can also install the [Agent Skills for Dart](https://github.com/dart-lang/skills) for Dart tasks.
+Plugins can package various customizations together. A key component of these plugins is **Agent Skills**, which are simple folders of files that can be seen as complementary to MCP: where MCP gives an agent access to specialized tools, a Skill teaches the agent “how” to use tools for a specific task.
+
+You can also install the [Agent Plugins for Dart](https://github.com/dart-lang/skills) for Dart tasks.
 
 ## Installation
 
-To install all skills into your project, run the following command. 
-The `--agent universal` flag puts it in the standard `.agents/skills` 
+To install the plugins into your project, run the following command. 
+The `--agent universal` flag puts them in the standard `.agents/skills` 
 folder that most agents use.
 
 ```bash
-npx skills add flutter/skills --skill '*' --agent universal --yes
+npx skills add flutter/agent-plugins --skill '*' --agent universal --yes
 ```
 
-## Updating Skills
+## Updating Plugins
 
 To update, run the following command:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Agent plugins for Flutter, maintained by the Flutter team.
 
-A collection of plugins designed to extend AI agent capabilities for Flutter development. These plugins bundle together skills, subagents, rules, and configurations to provide tailored workflows and instructions for happy path Flutter development. By giving the agent domain expertise and repeatable workflows, you drastically reduce mistakes and ensure agents reliably complete tasks following best practices.
+A collection of plugins designed to extend AI agent capabilities for Flutter development. These plugins bundle together skills, MCP server configuration, and rules to provide tailored workflows and instructions for happy path Flutter development. By giving the agent domain expertise and repeatable workflows, you drastically reduce mistakes and ensure agents reliably complete tasks following best practices.
 
 Plugins can package various customizations together. A key component of these plugins is **Agent Skills**, which are simple folders of files that can be seen as complementary to MCP: where MCP gives an agent access to specialized tools, a Skill teaches the agent “how” to use tools for a specific task.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of plugins designed to extend AI agent capabilities for Flutter dev
 
 Plugins can package various customizations together. A key component of these plugins is **Agent Skills**, which are simple folders of files that can be seen as complementary to MCP: where MCP gives an agent access to specialized tools, a Skill teaches the agent “how” to use tools for a specific task.
 
-You can also install the [Agent Plugins for Dart](https://github.com/dart-lang/skills) for Dart tasks.
+You can also install the [Dart skills](https://github.com/dart-lang/skills) for Dart tasks.
 
 ## Installation
 

--- a/tool/dart_skills_lint/README.md
+++ b/tool/dart_skills_lint/README.md
@@ -67,13 +67,13 @@ Release, verifies its SHA256, and installs to `/usr/local/bin` (with a
 `sudo` fallback). Supports macOS arm64 + x64 and Linux x64 + arm64.
 
 ```bash
-curl -fsSL https://github.com/flutter/skills/releases/latest/download/install.sh | bash
+curl -fsSL https://github.com/flutter/agent-plugins/releases/latest/download/install.sh | bash
 ```
 
 Optional env vars (set before the `bash` part):
 - `INSTALL_DIR` — install destination (default `/usr/local/bin`).
 - `VERSION` — pin a specific release like `0.4.0` (default `latest`).
-- `REPO` — alternate source repo (default `flutter/skills`).
+- `REPO` — alternate source repo (default `flutter/agent-plugins`).
 
 #### macOS first-launch note
 
@@ -91,13 +91,13 @@ This step goes away once notarized builds ship.
 
 For environments where piping a script to `bash` isn't acceptable.
 Grab the tarball for your platform from
-[the latest GitHub Release](https://github.com/flutter/skills/releases/latest)
+[the latest GitHub Release](https://github.com/flutter/agent-plugins/releases/latest)
 and verify its SHA256 against the release's `SHA256SUMS` asset.
 
 ```bash
 TARGET="linux-x64"     # or: macos-arm64, macos-x64, linux-arm64
 VERSION="0.4.0"
-BASE="https://github.com/flutter/skills/releases/download/dart_skills_lint-v${VERSION}"
+BASE="https://github.com/flutter/agent-plugins/releases/download/dart_skills_lint-v${VERSION}"
 curl -fsSLO "${BASE}/dart_skills_lint-${TARGET}.tar.gz"
 curl -fsSLO "${BASE}/SHA256SUMS"
 grep " dart_skills_lint-${TARGET}.tar.gz$" SHA256SUMS | sha256sum -c -

--- a/tool/dart_skills_lint/analysis_options.yaml
+++ b/tool/dart_skills_lint/analysis_options.yaml
@@ -17,7 +17,7 @@ analyzer:
     strict-raw-types: true
   # dart_code_linter is intentionally NOT registered as an analyzer
   # `plugin` here. When it was, `dart analyze` had racy false positives. 
-  # See https://github.com/flutter/skills/issues/144
+  # See https://github.com/flutter/agent-plugins/issues/144
   errors:
     # allow deprecated members (we do this because otherwise we have to annotate
     # every member in every test, assert, etc, when we or the Dart SDK deprecates

--- a/tool/dart_skills_lint/pubspec.yaml
+++ b/tool/dart_skills_lint/pubspec.yaml
@@ -5,8 +5,8 @@ description: >-
   pre-commit hooks.
 version: 0.4.0
 resolution: workspace
-repository: https://github.com/flutter/skills
-issue_tracker: https://github.com/flutter/skills/issues
+repository: https://github.com/flutter/agent-plugins
+issue_tracker: https://github.com/flutter/agent-plugins/issues
 
 topics:
   - agent-skills

--- a/tool/dart_skills_lint/scripts/install.sh
+++ b/tool/dart_skills_lint/scripts/install.sh
@@ -7,19 +7,19 @@
 # install.sh — Install the dart_skills_lint native binary.
 #
 # Usage (default repo + latest version):
-#   curl -fsSL https://github.com/flutter/skills/releases/latest/download/install.sh | bash
+#   curl -fsSL https://github.com/flutter/agent-plugins/releases/latest/download/install.sh | bash
 #
 # Pin a specific version or alternate repo:
 #   curl -fsSL .../install.sh | REPO=other-org/other-repo VERSION=0.4.0-dev.1 bash
 #
 # Env vars:
-#   REPO         GitHub owner/repo (default: flutter/skills).
+#   REPO         GitHub owner/repo (default: flutter/agent-plugins).
 #   VERSION      "latest" or a specific version like 0.4.0-dev.1 (default: latest).
 #   INSTALL_DIR  Install destination (default: /usr/local/bin).
 
 set -euo pipefail
 
-REPO="${REPO:-flutter/skills}"
+REPO="${REPO:-flutter/agent-plugins}"
 VERSION="${VERSION:-latest}"
 INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
 BIN_NAME="dart_skills_lint"

--- a/tool/dart_skills_lint/skills/dart-skills-lint-setup/SKILL.md
+++ b/tool/dart_skills_lint/skills/dart-skills-lint-setup/SKILL.md
@@ -25,7 +25,7 @@ see the [`Recipes` section of the README](../../README.md#recipes).
    dev_dependencies:
      dart_skills_lint:
        git:
-         url: https://github.com/flutter/skills.git
+         url: https://github.com/flutter/agent-plugins.git
          path: tool/dart_skills_lint
    ```
 

--- a/tool/dart_skills_lint/test/install_script_test.dart
+++ b/tool/dart_skills_lint/test/install_script_test.dart
@@ -131,7 +131,7 @@ void main() {
 
       // Get SHA256 sum
       var hash = '';
-      // TODO(reidbaker): Re-add CertUtil checksum verification for Windows hosts. https://github.com/flutter/skills/issues/164
+      // TODO(reidbaker): Re-add CertUtil checksum verification for Windows hosts. https://github.com/flutter/agent-plugins/issues/164
       final ProcessResult shaProcess = await Process.run('shasum', [
         '-a',
         '256',
@@ -174,7 +174,7 @@ void main() {
 
       await createMockRelease(os: os, arch: arch, binaryContent: binaryContent);
 
-      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/skills/issues/164
+      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/agent-plugins/issues/164
       final newPath = '${mockBinDir.path}:${Platform.environment['PATH']}';
       final String packageRoot = _getPackageRoot();
       final String scriptPath = p.join(packageRoot, 'scripts', 'install.sh');
@@ -271,7 +271,7 @@ void main() {
         shouldCorruptHash: true,
       );
 
-      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/skills/issues/164
+      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/agent-plugins/issues/164
       final newPath = '${mockBinDir.path}:${Platform.environment['PATH']}';
       final String packageRoot = _getPackageRoot();
       final String scriptPath = p.join(packageRoot, 'scripts', 'install.sh');
@@ -418,7 +418,7 @@ void main() {
     });
 
     test('fails on unsupported architecture', () async {
-      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/skills/issues/164
+      // TODO(reidbaker): Use Windows path separator (;) when running on Windows hosts. https://github.com/flutter/agent-plugins/issues/164
       final newPath = '${mockBinDir.path}:${Platform.environment['PATH']}';
       final String packageRoot = _getPackageRoot();
       final String scriptPath = p.join(packageRoot, 'scripts', 'install.sh');
@@ -438,7 +438,7 @@ void main() {
       expect(stderr.any((line) => line.contains('unsupported architecture')), isTrue);
       await process.shouldExit(1);
     });
-    // TODO(reidbaker): Support running install.sh tests on Windows hosts. https://github.com/flutter/skills/issues/164
+    // TODO(reidbaker): Support running install.sh tests on Windows hosts. https://github.com/flutter/agent-plugins/issues/164
   }, skip: Platform.isWindows ? 'install.sh is not supported on Windows' : null);
 }
 


### PR DESCRIPTION
This updates the README and any references to flutter/skills to point to flutter/agent-plugins. 

Once this lands, I will rename the repo.

The website docs are being updated here: https://github.com/flutter/website/pull/13568