### PR TITLE
feat: export RuleConfig and RuleConfigPatch right in dart_skills_lint.dart

### DIFF
--- a/tool/dart_skills_lint/lib/dart_skills_lint.dart
+++ b/tool/dart_skills_lint/lib/dart_skills_lint.dart
@@ -6,6 +6,7 @@ export 'src/config_parser.dart';
 export 'src/entry_point.dart';
 export 'src/models/analysis_severity.dart';
 export 'src/models/custom_rule_parameters.dart';
+export 'src/models/rule_config.dart';
 export 'src/models/skill_context.dart';
 export 'src/models/skill_rule.dart';
 export 'src/models/validation_error.dart';

--- a/tool/dart_skills_lint/test/api_defaults_test.dart
+++ b/tool/dart_skills_lint/test/api_defaults_test.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 import 'package:dart_skills_lint/dart_skills_lint.dart';
-import 'package:dart_skills_lint/src/models/rule_config.dart';
 import 'package:dart_skills_lint/src/rules/description_length_rule.dart';
 import 'package:dart_skills_lint/src/rules/trailing_whitespace_rule.dart';
 import 'package:dart_skills_lint/src/rules/valid_yaml_metadata_rule.dart';

--- a/tool/dart_skills_lint/test/rule_config_test.dart
+++ b/tool/dart_skills_lint/test/rule_config_test.dart
@@ -5,7 +5,6 @@
 import 'dart:io';
 
 import 'package:dart_skills_lint/dart_skills_lint.dart';
-import 'package:dart_skills_lint/src/models/rule_config.dart';
 import 'package:test/test.dart';
 import 'test_utils.dart';
 


### PR DESCRIPTION
Exposes `src/models/rule_config.dart` right across the public library entrypoint (`lib/dart_skills_lint.dart`) so external downstream consumers right can instantiate `RuleConfig` and `RuleConfigPatch` directly when migrating off deprecated `resolvedRules` arguments onto `resolvedRuleConfigs` without requiring implementation imports.

- Added `export 'src/models/rule_config.dart';` directly across `lib/dart_skills_lint.dart`.
- Cleaned up internal implementation imports inside `test/api_defaults_test.dart` and `test/rule_config_test.dart` to verify clean public class resolution.
- Verified zero static analysis warnings (`dart analyze --fatal-infos .`) and cleanly passed all 207 unit tests.