### PR TITLE
Migrate tool/generator test to ConfigParser.loadConfig and clean up workflow

### DIFF
--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -75,19 +75,6 @@ jobs:
           min_coverage: 73
           exclude: '**/*.g.dart'
 
-  validate_skills:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: stable
-
-      - run: dart pub get
-
-      - name: Validate skills
-        run: dart run dart_skills_lint:cli
-
   formatting:
     runs-on: ubuntu-latest
     steps:

--- a/tool/dart_skills_lint/.agents/skills/check-downstream-consumers/resources/known_consumers.md
+++ b/tool/dart_skills_lint/.agents/skills/check-downstream-consumers/resources/known_consumers.md
@@ -36,7 +36,7 @@ When evaluating the impact of pull requests on downstream repositories, check ag
 - **Primary Consumer Location**: Root skill sets or tooling harnesses.
 - **Tooling Engine**: `dart pub get` and `dart test`
 
-### 6. `kevmoo/dart-best-practices`
-- **Repository URL**: [kevmoo/dart-best-practices](https://github.com/kevmoo/dart-best-practices)
-- **Primary Consumer Location**: Root tooling verification tests.
+### 6. `kevmoo/dash_skills`
+- **Repository URL**: [kevmoo/dash_skills](https://github.com/kevmoo/dash_skills)
+- **Primary Consumer Location**: `tool/`
 - **Tooling Engine**: `dart pub get` and `dart test`

--- a/tool/dart_skills_lint/.agents/skills/dart-skills-lint-integration/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/dart-skills-lint-integration/SKILL.md
@@ -94,6 +94,11 @@ test('Validate Repository Skills', () async {
   final Configuration config = await ConfigParser.loadConfig(
     path: path.join(repoRoot.path, 'path', 'to', _configFileName),
   );
+  expect(
+    config.directoryConfigs,
+    isNotEmpty,
+    reason: 'Configuration directoryConfigs should not be empty.',
+  );
   final bool isValid = await validateSkills(
     skillDirPaths: [skillsDirectory], // Explicit absolute targeting
     config: config,

--- a/tool/dart_skills_lint/CONTRIBUTING.md
+++ b/tool/dart_skills_lint/CONTRIBUTING.md
@@ -58,6 +58,11 @@ void main() {
     // share configuration. Pass `customRules: [...]` to inject any
     // custom SkillRule implementations.
     final config = await ConfigParser.loadConfig();
+    expect(
+      config.directoryConfigs,
+      isNotEmpty,
+      reason: 'Configuration directoryConfigs should not be empty.',
+    );
     await validateSkills(config: config);
   });
 }

--- a/tool/dart_skills_lint/skills/dart-skills-lint-validation/SKILL.md
+++ b/tool/dart_skills_lint/skills/dart-skills-lint-validation/SKILL.md
@@ -93,6 +93,11 @@ import 'package:test/test.dart';
 void main() {
   test('skills pass with deprecated-skill custom rule', () async {
     final config = await ConfigParser.loadConfig();
+    expect(
+      config.directoryConfigs,
+      isNotEmpty,
+      reason: 'Configuration directoryConfigs should not be empty.',
+    );
     await validateSkills(
       config: config,
       customRules: [DeprecatedSkillRule()],

--- a/tool/dart_skills_lint/test/dart_skills_lint_skills_test.dart
+++ b/tool/dart_skills_lint/test/dart_skills_lint_skills_test.dart
@@ -20,6 +20,11 @@ void main() {
       // Load configuration from the default file (dart_skills_lint.yaml)
       // to mirror what is configured in the repository.
       final Configuration config = await ConfigParser.loadConfig();
+      expect(
+        config.directoryConfigs,
+        isNotEmpty,
+        reason: 'Configuration directoryConfigs should not be empty.',
+      );
 
       final bool isValid = await validateSkills(config: config);
       expect(isValid, isTrue, reason: 'Skills validation failed. See above for details.');

--- a/tool/generator/dart_skills_lint.yaml
+++ b/tool/generator/dart_skills_lint.yaml
@@ -1,0 +1,6 @@
+dart_skills_lint:
+  rules:
+    check-relative-paths: error
+    check-absolute-paths: error
+  directories:
+    - path: "../../skills"

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -19,11 +19,11 @@ void main() {
     });
 
     try {
-      final String packageDir = Directory.current.path.endsWith('generator')
+      final packageDir = Directory.current.path.endsWith('generator')
           ? Directory.current.path
           : p.join(Directory.current.path, 'tool', 'generator');
-      final String configPath = p.join(packageDir, 'dart_skills_lint.yaml');
-      final String skillsDir = p.normalize(p.join(packageDir, '..', '..', 'skills'));
+      final configPath = p.join(packageDir, 'dart_skills_lint.yaml');
+      final skillsDir = p.normalize(p.join(packageDir, '..', '..', 'skills'));
 
       final config = await ConfigParser.loadConfig(path: configPath);
       expect(

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
@@ -14,6 +16,12 @@ void main() {
     final subscription = Logger.root.onRecord.listen((record) {
       printOnFailure('${record.level.name}: ${record.message}');
     });
+
+    final originalDir = Directory.current;
+    final isRoot = !originalDir.path.endsWith('tool/generator');
+    if (isRoot) {
+      Directory.current = Directory('tool/generator');
+    }
 
     try {
       final config = await ConfigParser.loadConfig();
@@ -31,6 +39,9 @@ void main() {
         isTrue,
       );
     } finally {
+      if (isRoot) {
+        Directory.current = originalDir;
+      }
       await subscription.cancel();
     }
   });

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -20,9 +20,10 @@ void main() {
 
     final originalDir = Directory.current;
     final parts = p.split(originalDir.path);
-    final isRoot = !(parts.length >= 2 &&
-        parts[parts.length - 2] == 'tool' &&
-        parts.last == 'generator');
+    final isRoot =
+        !(parts.length >= 2 &&
+            parts[parts.length - 2] == 'tool' &&
+            parts.last == 'generator');
 
     if (isRoot) {
       Directory.current = Directory(p.join('tool', 'generator'));
@@ -37,10 +38,7 @@ void main() {
       );
 
       expect(
-        await validateSkills(
-          config: config,
-          customRules: [LastModifiedRule()],
-        ),
+        await validateSkills(config: config, customRules: [LastModifiedRule()]),
         isTrue,
       );
     } finally {

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -2,11 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:io';
-
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
-import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'custom_skill_rules/last_modified_rule.dart';
@@ -19,13 +16,7 @@ void main() {
     });
 
     try {
-      final packageDir = Directory.current.path.endsWith('generator')
-          ? Directory.current.path
-          : p.join(Directory.current.path, 'tool', 'generator');
-      final configPath = p.join(packageDir, 'dart_skills_lint.yaml');
-      final skillsDir = p.normalize(p.join(packageDir, '..', '..', 'skills'));
-
-      final config = await ConfigParser.loadConfig(path: configPath);
+      final config = await ConfigParser.loadConfig();
       expect(
         config.directoryConfigs,
         isNotEmpty,
@@ -34,7 +25,6 @@ void main() {
 
       expect(
         await validateSkills(
-          skillDirPaths: [skillsDir],
           config: config,
           customRules: [LastModifiedRule()],
         ),

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -2,8 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'custom_skill_rules/last_modified_rule.dart';
@@ -16,9 +19,22 @@ void main() {
     });
 
     try {
-      final config = await ConfigParser.loadConfig();
+      final String packageDir = Directory.current.path.endsWith('generator')
+          ? Directory.current.path
+          : p.join(Directory.current.path, 'tool', 'generator');
+      final String configPath = p.join(packageDir, 'dart_skills_lint.yaml');
+      final String skillsDir = p.normalize(p.join(packageDir, '..', '..', 'skills'));
+
+      final config = await ConfigParser.loadConfig(path: configPath);
+      expect(
+        config.directoryConfigs,
+        isNotEmpty,
+        reason: 'Configuration directoryConfigs should not be empty.',
+      );
+
       expect(
         await validateSkills(
+          skillDirPaths: [skillsDir],
           config: config,
           customRules: [LastModifiedRule()],
         ),

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -6,6 +6,7 @@ import 'dart:io';
 
 import 'package:dart_skills_lint/dart_skills_lint.dart';
 import 'package:logging/logging.dart';
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'custom_skill_rules/last_modified_rule.dart';
@@ -18,9 +19,13 @@ void main() {
     });
 
     final originalDir = Directory.current;
-    final isRoot = !originalDir.path.endsWith('tool/generator');
+    final parts = p.split(originalDir.path);
+    final isRoot = !(parts.length >= 2 &&
+        parts[parts.length - 2] == 'tool' &&
+        parts.last == 'generator');
+
     if (isRoot) {
-      Directory.current = Directory('tool/generator');
+      Directory.current = Directory(p.join('tool', 'generator'));
     }
 
     try {

--- a/tool/generator/test/lint_skills_test.dart
+++ b/tool/generator/test/lint_skills_test.dart
@@ -16,13 +16,10 @@ void main() {
     });
 
     try {
+      final config = await ConfigParser.loadConfig();
       expect(
         await validateSkills(
-          skillDirPaths: ['../../skills'],
-          resolvedRules: {
-            'check-relative-paths': AnalysisSeverity.error,
-            'check-absolute-paths': AnalysisSeverity.error,
-          },
+          config: config,
           customRules: [LastModifiedRule()],
         ),
         isTrue,


### PR DESCRIPTION
Update the style of dart_skills_lint validation to the most up to date pattern. That pattern is to use the yaml config style so that cli invocations and dart test invocations do the same thing with the exception of custom rules which can only be invoked with dart test. 

github actions are updated because the cli run is now duplicated work. 

Skills are updated because I found an easy to add false negative. 

Error on the consumers had the wrong kevmoo repo listed because I did not have it cloned locally. Once I did the repo was corrected. 