### PR TITLE
Add run-evals orchestration skill and evals for published skills

### DIFF
--- a/tool/dart_skills_lint/.agents/skills/.gitignore
+++ b/tool/dart_skills_lint/.agents/skills/.gitignore
@@ -7,6 +7,7 @@
 !check-downstream-consumers/
 !dart-skills-lint-integration/
 !definition-of-done/
+!run-evals/
 
 # Keep essential configuration and docs
 !.gitignore

--- a/tool/dart_skills_lint/.agents/skills/definition-of-done/evals/evals.json
+++ b/tool/dart_skills_lint/.agents/skills/definition-of-done/evals/evals.json
@@ -1,5 +1,8 @@
 {
   "skill_name": "definition-of-done",
+  "repo-criteria": [
+    "evals/code_quality_rubric.json"
+  ],
   "evals": [
     {
       "id": 1,

--- a/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
@@ -7,8 +7,6 @@ metadata:
 
 # Run Skill Evals
 
-Use this skill to run skill evaluations.
-
 1. **Read Framework**: Read `tool/dart_skills_lint/evals/README.md` for the exact subagent and grader prompts.
 2. **Locate Targets**: Find target `evals/evals.json` files inside `.agents/skills/` and/or `skills/`.
 3. **Orchestrate**: For each eval prompt, spawn two `bare-agent` subagents using `Workspace: branch`:

--- a/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: run-evals
+description: Run evaluations for one, multiple, or all skills using the agent orchestration framework. Make sure to use this skill whenever the user asks to run evals, test a skill's performance, run benchmarks, or compare baseline versus with-skill execution.
+metadata:
+  internal: true
+---
+
+# Run Skill Evals
+
+Use this skill to run skill evaluations.
+
+1. **Read Framework**: Read `tool/dart_skills_lint/evals/README.md` for the exact subagent and grader prompts.
+2. **Locate Targets**: Find target `evals/evals.json` files inside `.agents/skills/` and/or `skills/`.
+3. **Orchestrate**: For each eval prompt, spawn two `bare-agent` subagents using `Workspace: branch`:
+   - **Baseline**: Provide only the task prompt.
+   - **With-Skill**: Provide the task prompt + instructions to strictly follow the target skill file.
+   Instruct both to return their `git diff` and verification outputs (`dart format`, `dart analyze`, `dart test`) without committing.
+   **CRITICAL**: You must explicitly warn both subagents to confine all file edits strictly to their current working directory and avoid using absolute paths to modify the parent workspace.
+4. **Grade**: Parse the combined rubric (resolving `repo-criteria` + `evals.json` expectations).
+5. **Artifact**: Grade the outputs and generate a Markdown artifact (e.g., `<skill>_eval_results.md`) containing the metadata, pass/fail rationale, and raw diffs/stdout.

--- a/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/SKILL.md
@@ -9,10 +9,10 @@ metadata:
 
 1. **Read Framework**: Read `tool/dart_skills_lint/evals/README.md` for the exact subagent and grader prompts.
 2. **Locate Targets**: Find target `evals/evals.json` files inside `.agents/skills/` and/or `skills/`.
-3. **Orchestrate**: For each eval prompt, spawn two `bare-agent` subagents using `Workspace: branch`:
-   - **Baseline**: Provide only the task prompt.
-   - **With-Skill**: Provide the task prompt + instructions to strictly follow the target skill file.
-   Instruct both to return their `git diff` and verification outputs (`dart format`, `dart analyze`, `dart test`) without committing.
-   **CRITICAL**: You must explicitly warn both subagents to confine all file edits strictly to their current working directory and avoid using absolute paths to modify the parent workspace.
+3. **Orchestrate**: By default, run an Integration Test by spawning a single **With-Skill** `bare-agent` subagent using `Workspace: branch`.
+   - Provide the task prompt + instructions to strictly follow the target skill file.
+   - **Only if the user explicitly requests a comparison or benchmark**, also spawn a **Baseline** subagent (provided *only* the task prompt without skill instructions).
+   Instruct the subagent(s) to return their `git diff` and verification outputs (`dart format`, `dart analyze`, `dart test`) without committing.
+   **CRITICAL**: You must explicitly warn the subagent(s) to confine all file edits strictly to their current working directory and avoid using absolute paths to modify the parent workspace.
 4. **Grade**: Parse the combined rubric (resolving `repo-criteria` + `evals.json` expectations).
 5. **Artifact**: Grade the outputs and generate a Markdown artifact (e.g., `<skill>_eval_results.md`) containing the metadata, pass/fail rationale, and raw diffs/stdout.

--- a/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
@@ -7,7 +7,7 @@
     {
       "id": 1,
       "prompt": "Run the evals for the definition-of-done skill.",
-      "expected_output": "The agent orchestrates two subagents (baseline and with-skill) in branched workspaces, grades their git diffs and stdout, and outputs a markdown artifact.",
+      "expected_output": "The agent orchestrates a with-skill subagent in a branched workspace, grades its git diffs and stdout, and outputs a markdown artifact.",
       "expectations": [
         "The agent successfully triggered subagents to run the test cases.",
         "There is an artifact with the results.",
@@ -18,11 +18,22 @@
     {
       "id": 2,
       "prompt": "Can you test the dart-add-unit-test skill and see if it passes its rubric?",
-      "expected_output": "The agent identifies the target skill, spawns baseline and with-skill subagents, compares results, and writes an evaluation artifact.",
+      "expected_output": "The agent identifies the target skill, spawns a with-skill subagent, grades the result, and writes an evaluation artifact.",
       "expectations": [
         "There is an artifact with the results.",
         "No files are modified in the skill folder after the eval is done running.",
         "The evaluation artifact includes evals sourced from code_quality_rubric.json for a skill that produces code."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Run an A/B benchmark evaluation for the dart-add-unit-test skill, comparing it explicitly against a baseline without the skill.",
+      "expected_output": "The agent identifies the target skill, spawns both baseline and with-skill subagents, compares results, and writes a comprehensive evaluation artifact.",
+      "expectations": [
+        "The agent successfully triggered both baseline and with-skill subagents.",
+        "There is an artifact with the results.",
+        "The evaluation artifact contains explicit sections for both the 'With-Skill Agent' and the 'Baseline Agent'.",
+        "No files are modified in the skill folder after the eval is done running."
       ]
     }
   ]

--- a/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
@@ -1,0 +1,26 @@
+{
+  "skill_name": "run-evals",
+  "repo-criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Run the evals for the definition-of-done skill.",
+      "expected_output": "The agent orchestrates two subagents (baseline and with-skill) in branched workspaces, grades their git diffs and stdout, and outputs a markdown artifact.",
+      "expectations": [
+        "The agent successfully triggered subagents to run the test cases.",
+        "A markdown artifact containing the evaluation results was created.",
+        "The execution run leaves the parent working tree clean, with no rogue unstaged modifications to unrelated project files caused by subagents."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Can you test the dart-add-unit-test skill and see if it passes its rubric?",
+      "expected_output": "The agent identifies the target skill, spawns baseline and with-skill subagents, compares results, and writes an evaluation artifact.",
+      "expectations": [
+        "The execution run leaves the parent working tree clean, with no rogue unstaged modifications to unrelated project files caused by subagents."
+      ]
+    }
+  ]
+}

--- a/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
+++ b/tool/dart_skills_lint/.agents/skills/run-evals/evals/evals.json
@@ -10,8 +10,9 @@
       "expected_output": "The agent orchestrates two subagents (baseline and with-skill) in branched workspaces, grades their git diffs and stdout, and outputs a markdown artifact.",
       "expectations": [
         "The agent successfully triggered subagents to run the test cases.",
-        "A markdown artifact containing the evaluation results was created.",
-        "The execution run leaves the parent working tree clean, with no rogue unstaged modifications to unrelated project files caused by subagents."
+        "There is an artifact with the results.",
+        "No files are modified in the skill folder after the eval is done running.",
+        "The evaluation artifact includes evals sourced from code_quality_rubric.json for a skill that produces code."
       ]
     },
     {
@@ -19,7 +20,9 @@
       "prompt": "Can you test the dart-add-unit-test skill and see if it passes its rubric?",
       "expected_output": "The agent identifies the target skill, spawns baseline and with-skill subagents, compares results, and writes an evaluation artifact.",
       "expectations": [
-        "The execution run leaves the parent working tree clean, with no rogue unstaged modifications to unrelated project files caused by subagents."
+        "There is an artifact with the results.",
+        "No files are modified in the skill folder after the eval is done running.",
+        "The evaluation artifact includes evals sourced from code_quality_rubric.json for a skill that produces code."
       ]
     }
   ]

--- a/tool/dart_skills_lint/dart_skills_lint.yaml
+++ b/tool/dart_skills_lint/dart_skills_lint.yaml
@@ -35,4 +35,7 @@ dart_skills_lint:
     - path: ".agents/skills/definition-of-done"
       rules:
         prevent-skills-sh-publishing: error
+    - path: ".agents/skills/run-evals"
+      rules:
+        prevent-skills-sh-publishing: error
 

--- a/tool/dart_skills_lint/evals/README.md
+++ b/tool/dart_skills_lint/evals/README.md
@@ -1,6 +1,6 @@
 # Skill Evaluations (Evals) Framework
 
-This directory defines the architecture, rubrics, and instructions for evaluating AI agent skills authored and maintained in this repository using an LLM Agent as Judge.
+Architecture, rubrics, and instructions for evaluating AI agent skills authored and maintained in this repository using an LLM Agent as Judge.
 
 ## Core Principles & Architecture
 
@@ -40,7 +40,7 @@ When authoring or updating `evals.json`:
 Run the unit test that checks all `evals.json` files for structural consistency across the repository:
 
 ```bash
-dart test test/published_skills_evals_test.dart
+dart test test/skills_evals_test.dart
 ```
 
 ### 2. Running Evals via Agent Orchestration
@@ -79,7 +79,7 @@ Once you are done, do not commit. Just send me a message with the `git diff` of 
 When preparing to grade execution outputs, the orchestrator or grader agent must resolve the `repo-criteria` section from `evals.json`:
 
 1. **Parse `repo-criteria`**: Read the array of file paths defined under `"repo-criteria"` in `evals.json` (e.g., `["evals/code_quality_rubric.json"]`).
-2. **Load Referenced Rubrics**: Open each referenced JSON file relative to the repository root and extract its `expectations` list under `evaluations`.
+2. **Load Referenced Rubrics**: Open each referenced JSON file relative to the `tool/dart_skills_lint/` directory and extract its `expectations` list under `evaluations`.
 3. **Combine Expectations**: Concatenate the universal expectations from `repo-criteria` with the skill-specific `expectations` from `evals.json` to build the full grading payload.
 
 #### Agent Judge Grading

--- a/tool/dart_skills_lint/evals/README.md
+++ b/tool/dart_skills_lint/evals/README.md
@@ -47,9 +47,11 @@ dart test test/skills_evals_test.dart
 
 Within an agentic IDE, you can run evaluations interactively by instructing a parent orchestrator agent to spawn isolated subagents for execution, and then acting as the Agent Judge itself.
 
+By default, evaluations run in **Unary Integration Mode**—meaning only a With-Skill subagent is spawned and evaluated. A Baseline subagent is only spawned if the user explicitly requests a benchmark or A/B comparison.
+
 #### Subagent Execution Prompts
 
-For each test case in `evals.json`, spawn execution subagents using a branched workspace (`Workspace: branch`) to ensure isolation. Use these standard prompt structures:
+For each test case in `evals.json`, spawn execution subagent(s) using a branched workspace (`Workspace: branch`) to ensure isolation. Use these standard prompt structures:
 
 **With-Skill Execution Prompt:**
 ```text
@@ -63,11 +65,27 @@ WARNING: You are executing in an isolated branch workspace. Confine all file mod
 Once you are done, do not commit. Just send me a message with the `git diff` of your changes, and the output of running verification commands (e.g., `dart format`, `dart analyze`, `dart test`).
 ```
 
-**Baseline Execution Prompt (Without Skill):**
+**Baseline Execution Prompt (Without Skill Comparison):**
+Use this prompt if you are explicitly evaluating the value of a skill by comparing it against an agent that has zero specialized instructions.
 ```text
 Execute this task:
 - Task: <eval prompt>
 - Input files: <eval files if any, or "none">
+
+WARNING: You are executing in an isolated branch workspace. Confine all file modifications strictly to your current working directory. Do NOT use absolute paths to modify files in the parent workspace.
+
+Once you are done, do not commit. Just send me a message with the `git diff` of your changes, and the output of running verification commands (e.g., `dart format`, `dart analyze`, `dart test`).
+```
+
+**Baseline Execution Prompt (Main Branch Comparison):**
+Use this prompt if you are evaluating a PR and want to compare the feature branch's skill performance against the stable version of the skill on `main`.
+```text
+Execute this task:
+- Skill path: <path-to-skill> (Please read and STRICTLY FOLLOW the instructions in this skill file before finishing)
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+
+CRITICAL INSTRUCTION: Before beginning this task, you MUST run `git checkout main` to ensure you are executing the version of the skill that is currently on the main branch.
 
 WARNING: You are executing in an isolated branch workspace. Confine all file modifications strictly to your current working directory. Do NOT use absolute paths to modify files in the parent workspace.
 
@@ -109,6 +127,6 @@ After grading the outputs, the orchestrator agent must compile the results into 
 Please compile the complete evaluation results into a Markdown artifact (e.g., `<skill_name>_eval_results.md`). The document should include:
 1. Metadata at the top (Date, Skill Name, Model Evaluated, Prompt).
 2. A section for the "With-Skill Agent" containing the PASS/FAIL grade, rationale, and the raw outputs (`git diff` and command stdout).
-3. A section for the "Baseline Agent" containing the PASS/FAIL grade, rationale, and its raw outputs.
+3. If a comparison was explicitly requested, a section for the "Baseline Agent" containing the PASS/FAIL grade, rationale, and its raw outputs.
 ```
 This artifact serves as the permanent, human-readable record of the execution run.

--- a/tool/dart_skills_lint/evals/README.md
+++ b/tool/dart_skills_lint/evals/README.md
@@ -1,0 +1,114 @@
+# Skill Evaluations (Evals) Framework
+
+This directory defines the architecture, rubrics, and instructions for evaluating AI agent skills authored and maintained in this repository using an LLM Agent as Judge.
+
+## Core Principles & Architecture
+
+Evaluations in this repository use a **Two-Tiered Architecture** to separate domain-specific skill requirements from universal skill quality standards. The LLM Agent Judge evaluates execution runs against two components:
+
+1. **Domain Evals (`<skill_dir>/evals/evals.json`)**:
+   Skill-specific task prompts, macro narrative expected outputs, and micro expectation assertions unique to that skill.
+
+2. **Universal Skill Quality Rubrics (`evals/*_rubric.json`)**:
+   Modular, shared quality rubrics injected into the LLM Agent Judge system prompt representing universal quality classes required across skills.
+
+---
+
+### 1. Skill-Specific Evals (`<skill_dir>/evals/evals.json`)
+Each skill maintains an `evals/evals.json` file containing target task prompts and expectations:
+- **`prompt`**: Realistic user prompt testing primary or edge-case workflows.
+- **`expected_output`**: High-level narrative summary of success for human reviewers and judge context.
+- **`expectations`**: Array of discrete, testable assertions used by the judge to compute quantitative pass rates.
+- **`repo-criteria`**: Array of relative file paths to shared universal quality rubrics (e.g., `["evals/code_quality_rubric.json"]`).
+
+### 2. Universal Skill Quality Rubrics Framework (`evals/*_rubric.json`)
+Universal skill quality expectations are structured into modular rubric classes that apply broadly across skills.
+
+---
+
+## Key Rules for Writing Evals
+
+When authoring or updating `evals.json`:
+
+1. Maintain Schema Consistency across all `evals.json` files.
+
+---
+
+## 🚀 Running & Validating Evals Locally
+
+### 1. Validate Evals Structural Consistency
+Run the unit test that checks all `evals.json` files for structural consistency across the repository:
+
+```bash
+dart test test/published_skills_evals_test.dart
+```
+
+### 2. Running Evals via Agent Orchestration
+
+Within an agentic IDE, you can run evaluations interactively by instructing a parent orchestrator agent to spawn isolated subagents for execution, and then acting as the Agent Judge itself.
+
+#### Subagent Execution Prompts
+
+For each test case in `evals.json`, spawn execution subagents using a branched workspace (`Workspace: branch`) to ensure isolation. Use these standard prompt structures:
+
+**With-Skill Execution Prompt:**
+```text
+Execute this task:
+- Skill path: <path-to-skill> (Please read and STRICTLY FOLLOW the instructions in this skill file before finishing)
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+
+WARNING: You are executing in an isolated branch workspace. Confine all file modifications strictly to your current working directory. Do NOT use absolute paths to modify files in the parent workspace.
+
+Once you are done, do not commit. Just send me a message with the `git diff` of your changes, and the output of running verification commands (e.g., `dart format`, `dart analyze`, `dart test`).
+```
+
+**Baseline Execution Prompt (Without Skill):**
+```text
+Execute this task:
+- Task: <eval prompt>
+- Input files: <eval files if any, or "none">
+
+WARNING: You are executing in an isolated branch workspace. Confine all file modifications strictly to your current working directory. Do NOT use absolute paths to modify files in the parent workspace.
+
+Once you are done, do not commit. Just send me a message with the `git diff` of your changes, and the output of running verification commands (e.g., `dart format`, `dart analyze`, `dart test`).
+```
+
+#### Resolving `repo-criteria` for Grading
+
+When preparing to grade execution outputs, the orchestrator or grader agent must resolve the `repo-criteria` section from `evals.json`:
+
+1. **Parse `repo-criteria`**: Read the array of file paths defined under `"repo-criteria"` in `evals.json` (e.g., `["evals/code_quality_rubric.json"]`).
+2. **Load Referenced Rubrics**: Open each referenced JSON file relative to the repository root and extract its `expectations` list under `evaluations`.
+3. **Combine Expectations**: Concatenate the universal expectations from `repo-criteria` with the skill-specific `expectations` from `evals.json` to build the full grading payload.
+
+#### Agent Judge Grading
+
+Once execution subagents return their `git diff` and command outputs, grade the results using this prompt template:
+
+**Agent Judge Prompt:**
+```text
+You are an expert evaluator. Review the following execution outputs from an AI agent against the provided combined rubric. 
+
+Execution Outputs:
+- Git Diff: <diff>
+- Command Stdout: <test/analyze output>
+
+Combined Rubric Expectations:
+<combined expectations list>
+
+For each expectation, explicitly state whether it PASSED or FAILED and provide a 1-sentence justification. Finally, provide an overall PASS/FAIL grade.
+```
+
+#### Generating the Evaluation Artifact
+
+After grading the outputs, the orchestrator agent must compile the results into a markdown artifact so they can be easily reviewed.
+
+**Artifact Generation Prompt:**
+```text
+Please compile the complete evaluation results into a Markdown artifact (e.g., `<skill_name>_eval_results.md`). The document should include:
+1. Metadata at the top (Date, Skill Name, Model Evaluated, Prompt).
+2. A section for the "With-Skill Agent" containing the PASS/FAIL grade, rationale, and the raw outputs (`git diff` and command stdout).
+3. A section for the "Baseline Agent" containing the PASS/FAIL grade, rationale, and its raw outputs.
+```
+This artifact serves as the permanent, human-readable record of the execution run.

--- a/tool/dart_skills_lint/evals/code_quality_rubric.json
+++ b/tool/dart_skills_lint/evals/code_quality_rubric.json
@@ -1,0 +1,41 @@
+{
+  "rubric_name": "universal-code-quality-rubric",
+  "description": "Universal code quality class within the universal skill quality framework, injected into the LLM Agent Judge system prompt for code-generating skill execution runs.",
+  "evaluations": [
+    {
+      "category": "compilation_and_health",
+      "description": "Does the generated or modified code compile cleanly without syntax errors, pass static analysis ('dart analyze --fatal-infos'), and run successfully?",
+      "expectations": [
+        "The generated code compiles with zero syntax errors.",
+        "Static analysis passes cleanly ('dart analyze --fatal-infos' returns zero errors or warnings).",
+        "Existing and newly added unit, widget, or integration tests execute and pass successfully."
+      ]
+    },
+    {
+      "category": "effective_dart_and_idioms",
+      "description": "Does the code adhere to Effective Dart guidelines and modern Dart 3+ language features?",
+      "expectations": [
+        "Follows Effective Dart naming conventions, formatting, and structural guidelines.",
+        "Leverages Dart 3+ idioms where applicable (e.g. pattern matching, records, primary constructors, switch expressions).",
+        "Avoids anti-patterns such as unnecessary dynamic types or unhandled async calls."
+      ]
+    },
+    {
+      "category": "cross_platform_compatibility",
+      "description": "Does the solution function correctly across targeted host platforms (macOS, Linux, Windows)?",
+      "expectations": [
+        "File paths and CLI path parameters use platform-agnostic formatters (package:path or forward slashes '/').",
+        "CLI commands and shell invocation scripts use cross-platform compatible syntax.",
+        "Avoids hardcoded platform-specific environment paths (such as C:\\ or /usr/local/bin directly)."
+      ]
+    },
+    {
+      "category": "directory_and_placement_hygiene",
+      "description": "Are all created or modified files placed in canonical repository directories?",
+      "expectations": [
+        "Configuration files, source code, and tests are placed in their proper standard directory locations.",
+        "No temporary scratch files or orphaned directories are left behind after execution."
+      ]
+    }
+  ]
+}

--- a/tool/dart_skills_lint/skills/dart-skills-lint-setup/evals/evals.json
+++ b/tool/dart_skills_lint/skills/dart-skills-lint-setup/evals/evals.json
@@ -1,0 +1,48 @@
+{
+  "skill_name": "dart-skills-lint-setup",
+  "repo-criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Set up dart_skills_lint validation for the first time in our Dart project to lint skills located in .agents/skills.",
+      "expected_output": "The project's pubspec.yaml is updated with dart_skills_lint under dev_dependencies using a git dependency pointing to tool/dart_skills_lint, a root dart_skills_lint.yaml file is created specifying .agents/skills, and recipes for CI integration are provided.",
+      "expectations": [
+        "dart_skills_lint is added under dev_dependencies in pubspec.yaml as a git dependency targeting https://github.com/flutter/agent-plugins.git with path tool/dart_skills_lint.",
+        "The dart_skills_lint.yaml file is created at the repository root so both CLI and Dart test invocations share the configuration.",
+        "dart_skills_lint.yaml specifies .agents/skills under directories.",
+        "Configures check-relative-paths: error under rules in dart_skills_lint.yaml to enforce portable relative links across skill files.",
+        "Guidance or recipe for CI integration or pre-commit hook is provided.",
+        "NOT added under runtime dependencies in pubspec.yaml.",
+        "NOT placed inside .agents/skills/ or a sub-folder where root CLI commands will fail to locate the config."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "A repository has pre-existing skill files in .agents/skills with lint violations. Set up dart_skills_lint without failing CI or modifying legacy skill files by generating a baseline ignore file.",
+      "expected_output": "dart_skills_lint is added to pubspec.yaml dev_dependencies, a root dart_skills_lint.yaml configuration is created, and dart run dart_skills_lint:cli is executed with --generate-baseline to write violations to an ignore file without mutating legacy skill content.",
+      "expectations": [
+        "dart_skills_lint is configured under dev_dependencies in pubspec.yaml and dart_skills_lint.yaml is created at the repository root.",
+        "Configures check-relative-paths: error in dart_skills_lint.yaml to enforce portable path references.",
+        "The CLI command dart run dart_skills_lint:cli is run with --skills-directory=.agents/skills --generate-baseline to write legacy failures to an ignore file.",
+        "An explanation is provided that pre-existing violations exit clean while violations introduced after baseline generation will still fail validation.",
+        "Does NOT modify, delete, or reformat any pre-existing SKILL.md files in .agents/skills during baseline generation.",
+        "Does NOT pass --fix during baseline generation, keeping legacy skill files intact."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Set up dart_skills_lint to validate agent skills in .agents/skills, while isolating the package dependency inside tool/pubspec.yaml instead of adding it to the root pubspec.yaml.",
+      "expected_output": "The tool/ package's pubspec.yaml contains dart_skills_lint under dev_dependencies, while dart_skills_lint.yaml is placed at the repository root, ensuring the root closure is unpolluted and configuration remains centrally accessible.",
+      "expectations": [
+        "dart_skills_lint is added under dev_dependencies in tool/pubspec.yaml rather than the root pubspec.yaml.",
+        "dart_skills_lint.yaml is created at the repository root directory rather than inside tool/ so both CLI and test invocations share the configuration.",
+        "Configures check-relative-paths: error in dart_skills_lint.yaml to enforce portable path references.",
+        "Guidance is provided on ensuring dependency references and commit hashes remain synchronized if added to multiple pubspecs.",
+        "NOT placed inside tool/, which would prevent root-level CLI invocations from discovering the configuration file.",
+        "NOT added to the root pubspec.yaml dependencies or dev_dependencies."
+      ]
+    }
+  ]
+}

--- a/tool/dart_skills_lint/skills/dart-skills-lint-validation/evals/evals.json
+++ b/tool/dart_skills_lint/skills/dart-skills-lint-validation/evals/evals.json
@@ -1,0 +1,16 @@
+{
+  "skill_name": "dart-skills-lint-validation",
+  "repo-criteria": [
+    "evals/code_quality_rubric.json"
+  ],
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "TODO: Add a prompt to test dart-skills-lint-validation.",
+      "expected_output": "TODO: Define the expected high-level outcome.",
+      "expectations": [
+        "TODO: Add discrete expectations for the agent judge."
+      ]
+    }
+  ]
+}

--- a/tool/dart_skills_lint/skills/dart-skills-lint-validation/evals/evals.json
+++ b/tool/dart_skills_lint/skills/dart-skills-lint-validation/evals/evals.json
@@ -6,10 +6,37 @@
   "evals": [
     {
       "id": 1,
-      "prompt": "TODO: Add a prompt to test dart-skills-lint-validation.",
-      "expected_output": "TODO: Define the expected high-level outcome.",
+      "prompt": "Run dart_skills_lint validation on `example/skills/invalid` with the `--check-absolute-paths` flag. The fixture points to `/tmp/this/does/not/exist.md`, which cannot be auto-fixed since it does not exist. First, create a dummy file at an absolute path (e.g., `/tmp/dummy.md`), update the link in `example/skills/invalid/SKILL.md` to point to it, and then run `--fix --dry-run` to preview the auto-fix. Finally, run `--fix` to apply the fix and verify that the link was automatically converted to a relative path.",
+      "expected_output": "The agent explicitly enables the absolute paths rule, sets up a real absolute file target, previews the fix via dry-run, and automatically converts the link to a relative path via the CLI.",
       "expectations": [
-        "TODO: Add discrete expectations for the agent judge."
+        "The agent updated the SKILL.md link to point to an absolute path that actually exists on disk.",
+        "The agent ran the CLI with `--check-absolute-paths` and explicitly verified that a fixable path violation was found.",
+        "The agent used `--fix --dry-run` to preview the fix.",
+        "The agent successfully applied the fix using `--fix`, converting the absolute link into a relative one."
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Run dart_skills_lint validation on `example/skills/invalid` with `--disallowed-field` and `--check-absolute-paths` flags to surface all violations. Interpret the failures and manually fix all three violations (skill name mismatch, disallowed field, absolute path) without using the `--fix` flag. Ensure the final run is clean.",
+      "expected_output": "The agent explicitly enables the extra rules, identifies all violations, applies manual corrections to each without auto-fixing, and ensures a clean run.",
+      "expectations": [
+        "The agent executes the linter with the required flags to surface all violations.",
+        "The agent manually edits the skill files to fix the invalid skill name violation.",
+        "The agent manually edits the skill files to fix the disallowed field violation.",
+        "The agent manually edits the skill files to fix the absolute path violation.",
+        "The agent validates the directory again to confirm a clean run."
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Author a custom dart_skills_lint rule named `RequireInternalMetadataRule` that verifies if a skill's metadata contains `internal: true`. Wire it up into a new test file `test/custom_rule_test.dart`.",
+      "expected_output": "The agent writes a custom SkillRule and integrates it into a new unit test.",
+      "expectations": [
+        "The agent created a class extending `SkillRule`.",
+        "The agent implemented the `name` and `severity` overrides.",
+        "The `validate` method correctly parses the `parsedYaml` to check for `internal: true`.",
+        "The agent created a Dart test file that imports the custom rule and passes it to `validateSkills`.",
+        "The newly created test compiles and passes static analysis."
       ]
     }
   ]

--- a/tool/dart_skills_lint/test/skills_evals_test.dart
+++ b/tool/dart_skills_lint/test/skills_evals_test.dart
@@ -1,0 +1,137 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  group('Evals structure consistency', () {
+    // Ensures all evals.json files dynamically share the exact same JSON schema.
+    // Keys are not hardcoded to ensure enforcement remains schema-agnostic and flexible.
+    test('all evals.json files across skills share consistent structure and keys', () {
+      final List<File> evalsFiles = [
+        ..._findEvalsFiles(Directory(p.join(Directory.current.path, 'skills'))),
+        ..._findEvalsFiles(Directory(p.join(Directory.current.path, '.agents', 'skills'))),
+      ];
+
+      expect(
+        evalsFiles,
+        isNotEmpty,
+        reason: 'Should find at least one evals.json file in skills or .agents/skills.',
+      );
+
+      Set<String>? expectedRootKeys;
+      String? expectedRootKeysFilePath;
+      Set<String>? expectedEvalItemKeys;
+      String? expectedEvalItemFilePath;
+
+      for (final evalsFile in evalsFiles) {
+        final Directory skillDir = evalsFile.parent.parent;
+        final String skillName = p.basename(skillDir.path);
+
+        final Object? decoded = jsonDecode(evalsFile.readAsStringSync());
+        expect(
+          decoded,
+          isA<Map<String, dynamic>>(),
+          reason: '${evalsFile.path} must be a JSON map.',
+        );
+
+        if (decoded is! Map<String, dynamic>) {
+          fail('${evalsFile.path} must be a JSON map.');
+        }
+
+        expect(
+          decoded['skill_name'],
+          equals(skillName),
+          reason: 'skill_name in ${evalsFile.path} must match skill directory name "$skillName".',
+        );
+
+        final Set<String> rootKeys = decoded.keys.toSet();
+        if (expectedRootKeys == null) {
+          expectedRootKeys = rootKeys;
+          expectedRootKeysFilePath = evalsFile.path;
+        } else {
+          expect(
+            rootKeys,
+            equals(expectedRootKeys),
+            reason:
+                '${evalsFile.path} root keys do not match consistency pattern. '
+                'Expected keys to match the first processed file ($expectedRootKeysFilePath). '
+                'All evals.json files must share the exact same root keys.',
+          );
+        }
+
+        final Object? evalsRaw = decoded['evals'];
+        expect(
+          evalsRaw,
+          isA<List<dynamic>>(),
+          reason: 'evals key in ${evalsFile.path} must be a List.',
+        );
+
+        if (evalsRaw is! List<dynamic>) {
+          fail('evals key in ${evalsFile.path} must be a List.');
+        }
+
+        for (final Object? evalItem in evalsRaw) {
+          expect(
+            evalItem,
+            isA<Map<String, dynamic>>(),
+            reason: 'Item in evals list in ${evalsFile.path} must be a JSON map.',
+          );
+          if (evalItem is! Map<String, dynamic>) {
+            fail('Item in evals list in ${evalsFile.path} must be a JSON map.');
+          }
+
+          final Set<String> itemKeys = evalItem.keys.toSet();
+          if (expectedEvalItemKeys == null) {
+            expectedEvalItemKeys = itemKeys;
+            expectedEvalItemFilePath = evalsFile.path;
+          } else {
+            expect(
+              itemKeys,
+              equals(expectedEvalItemKeys),
+              reason:
+                  'Eval item in ${evalsFile.path} keys do not match consistency pattern. '
+                  'Expected eval item keys to match the first processed file ($expectedEvalItemFilePath). '
+                  'All eval items must share the exact same keys.',
+            );
+          }
+        }
+      }
+    });
+
+    test('all published skills have an evals.json file', () {
+      final skillsDir = Directory(p.join(Directory.current.path, 'skills'));
+      if (!skillsDir.existsSync()) {
+        return;
+      }
+
+      final List<Directory> skillDirs = skillsDir.listSync().whereType<Directory>().toList();
+
+      for (final skillDir in skillDirs) {
+        final evalsFile = File(p.join(skillDir.path, 'evals', 'evals.json'));
+        expect(
+          evalsFile.existsSync(),
+          isTrue,
+          reason:
+              'Published skill "${p.basename(skillDir.path)}" is missing an evals.json file at ${evalsFile.path}',
+        );
+      }
+    });
+  });
+}
+
+List<File> _findEvalsFiles(Directory baseDir) {
+  if (!baseDir.existsSync()) {
+    return [];
+  }
+  return baseDir
+      .listSync(recursive: true)
+      .whereType<File>()
+      .where((File f) => p.basename(f.path) == 'evals.json')
+      .toList();
+}

--- a/tool/dart_skills_lint/test/skills_evals_test.dart
+++ b/tool/dart_skills_lint/test/skills_evals_test.dart
@@ -115,6 +115,88 @@ void main() {
         );
       }
     });
+
+    test('all rubric JSON files in evals/ share consistent structure and keys', () {
+      final Directory rubricsDir = Directory(p.join(Directory.current.path, 'evals'));
+      if (!rubricsDir.existsSync()) return;
+
+      final List<File> rubricFiles = rubricsDir
+          .listSync(recursive: false)
+          .whereType<File>()
+          .where((File f) => f.path.endsWith('.json'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+      if (rubricFiles.isEmpty) return;
+
+      Set<String>? expectedRootKeys;
+      String? expectedRootKeysFilePath;
+      Set<String>? expectedEvalItemKeys;
+      String? expectedEvalItemFilePath;
+
+      for (final rubricFile in rubricFiles) {
+        final Object? decoded = jsonDecode(rubricFile.readAsStringSync());
+        expect(
+          decoded,
+          isA<Map<String, dynamic>>(),
+          reason: '${rubricFile.path} must be a JSON map.',
+        );
+
+        if (decoded is! Map<String, dynamic>) {
+          fail('${rubricFile.path} must be a JSON map.');
+        }
+
+        final Set<String> rootKeys = decoded.keys.toSet();
+        if (expectedRootKeys == null) {
+          expectedRootKeys = rootKeys;
+          expectedRootKeysFilePath = rubricFile.path;
+        } else {
+          expect(
+            rootKeys,
+            equals(expectedRootKeys),
+            reason:
+                '${rubricFile.path} root keys do not match consistency pattern. '
+                'Expected keys to match the first processed file ($expectedRootKeysFilePath).',
+          );
+        }
+
+        final Object? evalsRaw = decoded['evaluations'];
+        expect(
+          evalsRaw,
+          isA<List<dynamic>>(),
+          reason: 'evaluations key in ${rubricFile.path} must be a List.',
+        );
+
+        if (evalsRaw is! List<dynamic>) {
+          fail('evaluations key in ${rubricFile.path} must be a List.');
+        }
+
+        for (final Object? evalItem in evalsRaw) {
+          expect(
+            evalItem,
+            isA<Map<String, dynamic>>(),
+            reason: 'Item in evaluations list in ${rubricFile.path} must be a JSON map.',
+          );
+          if (evalItem is! Map<String, dynamic>) {
+            fail('Item in evaluations list in ${rubricFile.path} must be a JSON map.');
+          }
+
+          final Set<String> itemKeys = evalItem.keys.toSet();
+          if (expectedEvalItemKeys == null) {
+            expectedEvalItemKeys = itemKeys;
+            expectedEvalItemFilePath = rubricFile.path;
+          } else {
+            expect(
+              itemKeys,
+              equals(expectedEvalItemKeys),
+              reason:
+                  'Evaluation item in ${rubricFile.path} keys do not match consistency pattern. '
+                  'Expected eval item keys to match the first processed file ($expectedEvalItemFilePath).',
+            );
+          }
+        }
+      }
+    });
   });
 }
 

--- a/tool/dart_skills_lint/test/skills_evals_test.dart
+++ b/tool/dart_skills_lint/test/skills_evals_test.dart
@@ -24,75 +24,7 @@ void main() {
         reason: 'Should find at least one evals.json file in skills or .agents/skills.',
       );
 
-      Set<String>? expectedRootKeys;
-      String? expectedRootKeysFilePath;
-      Set<String>? expectedEvalItemKeys;
-      String? expectedEvalItemFilePath;
-
-      for (final evalsFile in evalsFiles) {
-        final Object? decoded = jsonDecode(evalsFile.readAsStringSync());
-        expect(
-          decoded,
-          isA<Map<String, dynamic>>(),
-          reason: '${evalsFile.path} must be a JSON map.',
-        );
-
-        if (decoded is! Map<String, dynamic>) {
-          fail('${evalsFile.path} must be a JSON map.');
-        }
-
-        final Set<String> rootKeys = decoded.keys.toSet();
-        if (expectedRootKeys == null) {
-          expectedRootKeys = rootKeys;
-          expectedRootKeysFilePath = evalsFile.path;
-        } else {
-          expect(
-            rootKeys,
-            equals(expectedRootKeys),
-            reason:
-                '${evalsFile.path} root keys do not match consistency pattern. '
-                'Expected keys to match the first processed file ($expectedRootKeysFilePath). '
-                'All evals.json files must share the exact same root keys.',
-          );
-        }
-
-        final Object? evalsRaw = decoded['evals'];
-        expect(
-          evalsRaw,
-          isA<List<dynamic>>(),
-          reason: 'evals key in ${evalsFile.path} must be a List.',
-        );
-
-        if (evalsRaw is! List<dynamic>) {
-          fail('evals key in ${evalsFile.path} must be a List.');
-        }
-
-        for (final Object? evalItem in evalsRaw) {
-          expect(
-            evalItem,
-            isA<Map<String, dynamic>>(),
-            reason: 'Item in evals list in ${evalsFile.path} must be a JSON map.',
-          );
-          if (evalItem is! Map<String, dynamic>) {
-            fail('Item in evals list in ${evalsFile.path} must be a JSON map.');
-          }
-
-          final Set<String> itemKeys = evalItem.keys.toSet();
-          if (expectedEvalItemKeys == null) {
-            expectedEvalItemKeys = itemKeys;
-            expectedEvalItemFilePath = evalsFile.path;
-          } else {
-            expect(
-              itemKeys,
-              equals(expectedEvalItemKeys),
-              reason:
-                  'Eval item in ${evalsFile.path} keys do not match consistency pattern. '
-                  'Expected eval item keys to match the first processed file ($expectedEvalItemFilePath). '
-                  'All eval items must share the exact same keys.',
-            );
-          }
-        }
-      }
+      _verifyStructuralConsistency(evalsFiles, 'evals');
     });
 
     // Note: We intentionally only require an evals.json file for published skills.
@@ -117,87 +49,88 @@ void main() {
     });
 
     test('all rubric JSON files in evals/ share consistent structure and keys', () {
-      final Directory rubricsDir = Directory(p.join(Directory.current.path, 'evals'));
-      if (!rubricsDir.existsSync()) return;
-
-      final List<File> rubricFiles = rubricsDir
-          .listSync(recursive: false)
-          .whereType<File>()
-          .where((File f) => f.path.endsWith('.json'))
-          .toList()
-        ..sort((a, b) => a.path.compareTo(b.path));
-
-      if (rubricFiles.isEmpty) return;
-
-      Set<String>? expectedRootKeys;
-      String? expectedRootKeysFilePath;
-      Set<String>? expectedEvalItemKeys;
-      String? expectedEvalItemFilePath;
-
-      for (final rubricFile in rubricFiles) {
-        final Object? decoded = jsonDecode(rubricFile.readAsStringSync());
-        expect(
-          decoded,
-          isA<Map<String, dynamic>>(),
-          reason: '${rubricFile.path} must be a JSON map.',
-        );
-
-        if (decoded is! Map<String, dynamic>) {
-          fail('${rubricFile.path} must be a JSON map.');
-        }
-
-        final Set<String> rootKeys = decoded.keys.toSet();
-        if (expectedRootKeys == null) {
-          expectedRootKeys = rootKeys;
-          expectedRootKeysFilePath = rubricFile.path;
-        } else {
-          expect(
-            rootKeys,
-            equals(expectedRootKeys),
-            reason:
-                '${rubricFile.path} root keys do not match consistency pattern. '
-                'Expected keys to match the first processed file ($expectedRootKeysFilePath).',
-          );
-        }
-
-        final Object? evalsRaw = decoded['evaluations'];
-        expect(
-          evalsRaw,
-          isA<List<dynamic>>(),
-          reason: 'evaluations key in ${rubricFile.path} must be a List.',
-        );
-
-        if (evalsRaw is! List<dynamic>) {
-          fail('evaluations key in ${rubricFile.path} must be a List.');
-        }
-
-        for (final Object? evalItem in evalsRaw) {
-          expect(
-            evalItem,
-            isA<Map<String, dynamic>>(),
-            reason: 'Item in evaluations list in ${rubricFile.path} must be a JSON map.',
-          );
-          if (evalItem is! Map<String, dynamic>) {
-            fail('Item in evaluations list in ${rubricFile.path} must be a JSON map.');
-          }
-
-          final Set<String> itemKeys = evalItem.keys.toSet();
-          if (expectedEvalItemKeys == null) {
-            expectedEvalItemKeys = itemKeys;
-            expectedEvalItemFilePath = rubricFile.path;
-          } else {
-            expect(
-              itemKeys,
-              equals(expectedEvalItemKeys),
-              reason:
-                  'Evaluation item in ${rubricFile.path} keys do not match consistency pattern. '
-                  'Expected eval item keys to match the first processed file ($expectedEvalItemFilePath).',
-            );
-          }
-        }
+      final rubricsDir = Directory(p.join(Directory.current.path, 'evals'));
+      if (!rubricsDir.existsSync()) {
+        return;
       }
+
+      final List<File> rubricFiles =
+          rubricsDir
+              .listSync()
+              .whereType<File>()
+              .where((File f) => f.path.endsWith('.json'))
+              .toList()
+            ..sort((a, b) => a.path.compareTo(b.path));
+
+      if (rubricFiles.isEmpty) {
+        return;
+      }
+
+      _verifyStructuralConsistency(rubricFiles, 'evaluations');
     });
   });
+}
+
+void _verifyStructuralConsistency(List<File> files, String itemsKey) {
+  Set<String>? expectedRootKeys;
+  String? expectedRootKeysFilePath;
+  Set<String>? expectedItemKeys;
+  String? expectedItemFilePath;
+
+  for (final file in files) {
+    final Object? decoded = jsonDecode(file.readAsStringSync());
+    expect(decoded, isA<Map<String, dynamic>>(), reason: '${file.path} must be a JSON map.');
+
+    if (decoded is! Map<String, dynamic>) {
+      fail('${file.path} must be a JSON map.');
+    }
+
+    final Set<String> rootKeys = decoded.keys.toSet();
+    if (expectedRootKeys == null) {
+      expectedRootKeys = rootKeys;
+      expectedRootKeysFilePath = file.path;
+    } else {
+      expect(
+        rootKeys,
+        equals(expectedRootKeys),
+        reason:
+            '${file.path} root keys do not match consistency pattern. '
+            'Expected keys to match the first processed file ($expectedRootKeysFilePath).',
+      );
+    }
+
+    final Object? itemsRaw = decoded[itemsKey];
+    expect(itemsRaw, isA<List<dynamic>>(), reason: '$itemsKey key in ${file.path} must be a List.');
+
+    if (itemsRaw is! List<dynamic>) {
+      fail('$itemsKey key in ${file.path} must be a List.');
+    }
+
+    for (final Object? item in itemsRaw) {
+      expect(
+        item,
+        isA<Map<String, dynamic>>(),
+        reason: 'Item in $itemsKey list in ${file.path} must be a JSON map.',
+      );
+      if (item is! Map<String, dynamic>) {
+        fail('Item in $itemsKey list in ${file.path} must be a JSON map.');
+      }
+
+      final Set<String> itemKeys = item.keys.toSet();
+      if (expectedItemKeys == null) {
+        expectedItemKeys = itemKeys;
+        expectedItemFilePath = file.path;
+      } else {
+        expect(
+          itemKeys,
+          equals(expectedItemKeys),
+          reason:
+              'Item in ${file.path} keys do not match consistency pattern. '
+              'Expected item keys to match the first processed file ($expectedItemFilePath).',
+        );
+      }
+    }
+  }
 }
 
 List<File> _findEvalsFiles(Directory baseDir) {

--- a/tool/dart_skills_lint/test/skills_evals_test.dart
+++ b/tool/dart_skills_lint/test/skills_evals_test.dart
@@ -16,7 +16,7 @@ void main() {
       final List<File> evalsFiles = [
         ..._findEvalsFiles(Directory(p.join(Directory.current.path, 'skills'))),
         ..._findEvalsFiles(Directory(p.join(Directory.current.path, '.agents', 'skills'))),
-      ];
+      ]..sort((a, b) => a.path.compareTo(b.path));
 
       expect(
         evalsFiles,
@@ -30,9 +30,6 @@ void main() {
       String? expectedEvalItemFilePath;
 
       for (final evalsFile in evalsFiles) {
-        final Directory skillDir = evalsFile.parent.parent;
-        final String skillName = p.basename(skillDir.path);
-
         final Object? decoded = jsonDecode(evalsFile.readAsStringSync());
         expect(
           decoded,
@@ -43,12 +40,6 @@ void main() {
         if (decoded is! Map<String, dynamic>) {
           fail('${evalsFile.path} must be a JSON map.');
         }
-
-        expect(
-          decoded['skill_name'],
-          equals(skillName),
-          reason: 'skill_name in ${evalsFile.path} must match skill directory name "$skillName".',
-        );
 
         final Set<String> rootKeys = decoded.keys.toSet();
         if (expectedRootKeys == null) {
@@ -104,6 +95,8 @@ void main() {
       }
     });
 
+    // Note: We intentionally only require an evals.json file for published skills.
+    // Contributor skills in .agents/skills/ are not currently required to have one.
     test('all published skills have an evals.json file', () {
       final skillsDir = Directory(p.join(Directory.current.path, 'skills'));
       if (!skillsDir.existsSync()) {


### PR DESCRIPTION
## Description

This PR introduces the `run-evals` orchestration skill, adds structural consistency testing, and creates `evals.json` tests for all published skills in the `dart_skills_lint` package.

The `run-evals` skill executes evaluations for each skill in complete isolation (using a branched workspace).

## Changes

- **`skills/run-evals/`**: Added the orchestration skill for executing skill evaluations in isolated branch workspaces.
- **`evals/`**: Added `evals/README.md` and `code_quality_rubric.json` to introduce a two-tiered evaluation architecture. This architecture separates skill-specific task assertions (defined in individual `evals.json` files) from universal quality standards (defined in shared rubric files). This modular approach allows us to enforce broad health and quality expectations across all agent runs without duplicating them into every skill's evaluation file.
- **`test/skills_evals_test.dart`**: Added a test suite enforcing that all published skills in `skills/` contain an `evals.json` file. It also guarantees that every `evals.json` file across the repository shares the exact same JSON structure, while keeping that structure schema-agnostic and flexible.
