### PR TITLE
feat: add contributor-pr-description skill

### DIFF
--- a/tool/dart_skills_lint/.agents/skills/.gitignore
+++ b/tool/dart_skills_lint/.agents/skills/.gitignore
@@ -3,6 +3,7 @@
 *.log
 
 # Un-ignore specific checked-in skills
+!contributor-pr-description/
 !add-dart-lint-validation-rule/
 !check-downstream-consumers/
 !dart-skills-lint-integration/

--- a/tool/dart_skills_lint/.agents/skills/contributor-pr-description/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/contributor-pr-description/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: contributor-pr-description
 description: Guidelines and format for writing pull request descriptions in this repository. Use this skill whenever the user asks you to draft a pull request description, submit a PR, or update a PR description.
+metadata:
+  internal: true
 ---
 
 # Pull Request Description Guidelines

--- a/tool/dart_skills_lint/.agents/skills/contributor-pr-description/SKILL.md
+++ b/tool/dart_skills_lint/.agents/skills/contributor-pr-description/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: contributor-pr-description
+description: Guidelines and format for writing pull request descriptions in this repository. Use this skill whenever the user asks you to draft a pull request description, submit a PR, or update a PR description.
+---
+
+# Pull Request Description Guidelines
+
+When writing a pull request (PR) description, your goal is to provide reviewers with enough context to understand what you did, why you did it, and how they can verify it. A good PR description speeds up the review process and serves as documentation for future contributors.
+
+## Identity Verification
+
+If you are in an environment where there are multiple GitHub identities (e.g., an AI agent identity and a primary user identity), **you must verify your identity before pushing or creating a PR**.
+
+Before committing, pushing, or opening a PR, ensure you are using the identity that the user expects based on the type of work and the repository you are working on. Verify your active GitHub CLI auth (`gh auth status`) and ensure your Git commit author (`git commit --author="..."`) matches the correct identity for the task.
+
+## PR Description Template
+
+Always use the following template (or a very similar structure) when drafting a PR description:
+
+```markdown
+## Summary
+[Provide a clear, 1-2 sentence summary of what this PR does.]
+
+## Motivation and Context
+[Explain why this change is necessary. What problem does it solve? If it's a bug fix, what was the broken behavior?]
+
+## Related Issues
+[If this PR fixes an open issue, link to it using keywords. e.g., "Fixes #123" or "Closes #456". If it relates to an issue but doesn't close it, use "Related to #789".]
+
+## What changed
+[Optional: Provide a bulleted list of the most important technical changes made in the code. This is useful for larger PRs.]
+- Added `FooClass` to handle XYZ.
+- Updated `BarMethod` to return `Result`.
+
+## Testing Instructions
+[Explain how reviewers can test your changes locally. Mention any manual verification steps.]
+- Run `dart test` to ensure all tests pass.
+- [Any specific manual testing steps]
+
+```
+
+## Tone and Style
+
+1. **Be clear and concise**: Avoid rambling. Use bullet points for readability.
+2. **Focus on the "Why"**: The diff shows *what* changed. The description should explain *why* it changed.
+3. **Be professional**: Use natural, accessible language.
+
+## Examples of Bad vs Good Summaries
+
+**Bad**: "Fixed the bug." (Too vague, doesn't explain what bug)
+**Bad**: "Changed line 42 in `main.dart` to use `foo` instead of `bar`." (Focuses too much on the code, which is visible in the diff)
+
+**Good**: "Fixes a crash when the user clicks 'Submit' without entering an email address by adding validation to the input form." (Explains the problem and the solution)

--- a/tool/dart_skills_lint/dart_skills_lint.yaml
+++ b/tool/dart_skills_lint/dart_skills_lint.yaml
@@ -35,4 +35,7 @@ dart_skills_lint:
     - path: ".agents/skills/definition-of-done"
       rules:
         prevent-skills-sh-publishing: error
+    - path: ".agents/skills/contributor-pr-description"
+      rules:
+        prevent-skills-sh-publishing: error
 


### PR DESCRIPTION
## Summary
This PR introduces the `contributor-pr-description` skill to guide contributors and AI agents on how to author well-structured pull request descriptions.

## Motivation and Context
Previously, agents (like myself) and contributors could open PRs with extremely brief or poorly formatted descriptions, omitting crucial context. Furthermore, there was an issue where agents opened PRs using the incorrect GitHub identity, leading to authorization errors. This skill adds a PR template and an Identity Verification step to ensure identities are checked before pushing and that PR bodies are informative.

## Related Issues
N/A

## What changed
- Created `.agents/skills/contributor-pr-description/SKILL.md` containing the PR description guidelines, template, and identity verification checklist.
- Un-ignored the `contributor-pr-description` directory in `.agents/skills/.gitignore`.
- Configured `dart_skills_lint.yaml` to enforce the `prevent-skills-sh-publishing: error` rule for this new internal skill.

## Testing Instructions
- Review the `SKILL.md` content for clarity and accuracy.
- Verify that `dart run dart_skills_lint -d .agents/skills` passes locally, confirming the skill is valid and properly marked as internal.
