### PR TITLE
Configure bot to sync skills and fix zizmor warnings

### DIFF
--- a/.github/workflows/block-dart-skills-prs.yaml
+++ b/.github/workflows/block-dart-skills-prs.yaml
@@ -4,9 +4,9 @@ permissions:
   contents: read
   pull-requests: write
 
-# zizmor: ignore[dangerous-triggers]
+# zizmor: ignore[dangerous-triggers] - {Needed to detect when Dart skills are modified}
 on:
-  # zizmor: ignore[dangerous-triggers]
+  # zizmor: ignore[dangerous-triggers] - {Needed to detect when Dart skills are modified}
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/block-dart-skills-prs.yaml
+++ b/.github/workflows/block-dart-skills-prs.yaml
@@ -18,7 +18,7 @@ jobs:
       github.event.pull_request.head.ref != 'automation/sync-dart-skills'
     steps:
       - name: Fail Action and Comment on PR
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const prNumber = context.payload.pull_request.number;

--- a/.github/workflows/block-dart-skills-prs.yaml
+++ b/.github/workflows/block-dart-skills-prs.yaml
@@ -1,6 +1,12 @@
 name: Block Upstream Skill Modifications
 
+permissions:
+  contents: read
+  pull-requests: write
+
+# zizmor: ignore[dangerous-triggers]
 on:
+  # zizmor: ignore[dangerous-triggers]
   pull_request_target:
     types: [opened, synchronize, reopened]
     paths:

--- a/.github/workflows/dart_skills_lint_release.yaml
+++ b/.github/workflows/dart_skills_lint_release.yaml
@@ -1,5 +1,6 @@
 name: dart_skills_lint release
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   push:
@@ -146,10 +147,6 @@ jobs:
           VERSION: ${{ steps.meta.outputs.version }}
 
       - name: Create GitHub Release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          STEPS_META_OUTPUTS_PRERELEASE: ${{ steps.meta.outputs.prerelease }}
-          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
           
@@ -165,3 +162,7 @@ jobs:
             dist/*.tar.gz \
             dist/SHA256SUMS \
             tool/dart_skills_lint/scripts/install.sh
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_META_OUTPUTS_PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}

--- a/.github/workflows/dart_skills_lint_release.yaml
+++ b/.github/workflows/dart_skills_lint_release.yaml
@@ -26,9 +26,11 @@ jobs:
         working-directory: tool/dart_skills_lint
         shell: bash
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
-      - uses: dart-lang/setup-dart@v1
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 
@@ -61,7 +63,7 @@ jobs:
           TARGET: ${{ matrix.target }}
 
       - name: Upload binary artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dart_skills_lint-${{ matrix.target }}
           path: |
@@ -79,10 +81,12 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Download all binary artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: dist
           merge-multiple: true
@@ -144,16 +148,18 @@ jobs:
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          STEPS_META_OUTPUTS_PRERELEASE: ${{ steps.meta.outputs.prerelease }}
+          STEPS_META_OUTPUTS_VERSION: ${{ steps.meta.outputs.version }}
         run: |
           set -euo pipefail
           
           PRERELEASE_FLAG=""
-          if [ "${{ steps.meta.outputs.prerelease }}" = "true" ]; then
+          if [ "${STEPS_META_OUTPUTS_PRERELEASE}" = "true" ]; then
             PRERELEASE_FLAG="--prerelease"
           fi
           
-          gh release create "${{ github.ref_name }}" \
-            --title "dart_skills_lint v${{ steps.meta.outputs.version }}" \
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "dart_skills_lint v${STEPS_META_OUTPUTS_VERSION}" \
             --notes-file release-notes.md \
             $PRERELEASE_FLAG \
             dist/*.tar.gz \

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -54,7 +54,7 @@ jobs:
           dart run bin/main.dart
 
   coverage:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1 # zizmor: ignore[unpinned-uses]
     with:
       working_directory: tool/dart_skills_lint
       min_coverage: 73

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -54,7 +54,7 @@ jobs:
           dart run bin/main.dart
 
   coverage:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v86e2d68bb1e27b2518e4a2277205d23d21cb413c
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@86e2d68bb1e27b2518e4a2277205d23d21cb413c # v1
     with:
       working_directory: tool/dart_skills_lint
       min_coverage: 73

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -1,5 +1,6 @@
 name: dart_skills_lint
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   pull_request:
@@ -72,6 +73,7 @@ jobs:
 
       # Action steps do not inherit defaults.run.working-directory, so this
       # path is relative to the repository root.
+      # zizmor: ignore[archived-uses]
       - name: Enforce coverage threshold
         uses: VeryGoodOpenSource/very_good_coverage@c953fca3e24a915e111cc6f55f03f756dcb3964c # v3
         with:

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -54,31 +54,11 @@ jobs:
           dart run bin/main.dart
 
   coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-        with:
-          sdk: stable
-
-      - run: dart pub get
-
-      - name: Collect coverage
-        run: dart test --coverage=coverage
-
-      - name: Format coverage to LCOV
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
-
-      # Action steps do not inherit defaults.run.working-directory, so this
-      # path is relative to the repository root.
-      - name: Enforce coverage threshold
-        uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@<86e2d68bb1e27b2518e4a2277205d23d21cb413c
-        with:
-          path: tool/dart_skills_lint/coverage/lcov.info
-          min_coverage: 73
-          exclude: '**/*.g.dart'
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v86e2d68bb1e27b2518e4a2277205d23d21cb413c
+    with:
+      working_directory: tool/dart_skills_lint
+      min_coverage: 73
+      exclude: '**/*.g.dart'
 
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -54,10 +54,31 @@ jobs:
           dart run bin/main.dart
 
   coverage:
-    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1 # zizmor: ignore[unpinned-uses]
-    with:
-      working_directory: tool/dart_skills_lint
-      min_coverage: 73
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
+        with:
+          sdk: stable
+
+      - run: dart pub get
+
+      - name: Collect coverage
+        run: dart test --coverage=coverage
+
+      - name: Format coverage to LCOV
+        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
+
+      # Action steps do not inherit defaults.run.working-directory, so this
+      # path is relative to the repository root.
+      - name: Enforce coverage threshold
+        uses: VeryGoodOpenSource/very_good_coverage@c953fca3e24a915e111cc6f55f03f756dcb3964c # v3 # zizmor: ignore[archived-uses]
+        with:
+          path: tool/dart_skills_lint/coverage/lcov.info
+          min_coverage: 73
+          exclude: '**/*.g.dart'
 
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -54,32 +54,10 @@ jobs:
           dart run bin/main.dart
 
   coverage:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
-        with:
-          sdk: stable
-
-      - run: dart pub get
-
-      - name: Collect coverage
-        run: dart test --coverage=coverage
-
-      - name: Format coverage to LCOV
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage/lcov.info --report-on=lib
-
-      # Action steps do not inherit defaults.run.working-directory, so this
-      # path is relative to the repository root.
-      # zizmor: ignore[archived-uses]
-      - name: Enforce coverage threshold
-        uses: VeryGoodOpenSource/very_good_coverage@c953fca3e24a915e111cc6f55f03f756dcb3964c # v3
-        with:
-          path: tool/dart_skills_lint/coverage/lcov.info
-          min_coverage: 73
-          exclude: '**/*.g.dart'
+    uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@v1
+    with:
+      working_directory: tool/dart_skills_lint
+      min_coverage: 73
 
   formatting:
     runs-on: ubuntu-latest

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -74,7 +74,7 @@ jobs:
       # Action steps do not inherit defaults.run.working-directory, so this
       # path is relative to the repository root.
       - name: Enforce coverage threshold
-        uses: VeryGoodOpenSource/very_good_coverage@c953fca3e24a915e111cc6f55f03f756dcb3964c # v3 # zizmor: ignore[archived-uses]
+        uses: VeryGoodOpenSource/very_good_workflows/.github/workflows/dart_package.yml@<86e2d68bb1e27b2518e4a2277205d23d21cb413c
         with:
           path: tool/dart_skills_lint/coverage/lcov.info
           min_coverage: 73

--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -28,8 +28,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 
@@ -53,8 +55,10 @@ jobs:
   coverage:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 
@@ -78,8 +82,10 @@ jobs:
   formatting:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 
@@ -90,8 +96,10 @@ jobs:
   pana_score:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 

--- a/.github/workflows/skills_tool.yaml
+++ b/.github/workflows/skills_tool.yaml
@@ -27,8 +27,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 
@@ -41,8 +43,10 @@ jobs:
   formatting_stable_ubuntu-latest:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: dart-lang/setup-dart@v1
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 

--- a/.github/workflows/skills_tool.yaml
+++ b/.github/workflows/skills_tool.yaml
@@ -1,5 +1,6 @@
 name: skills_tool
-permissions: read-all
+permissions:
+  contents: read
 
 on:
   # Run CI on all PRs (against any branch) and on pushes to the main branch.

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -1,77 +1,54 @@
-name: Sync Skills Directory via Git Hash (Dart)
+name: Sync Skills Directory
 
 on:
   schedule:
-    - cron: '0 0 * * *' # Keep the daily check as a fallback safety net
-  workflow_dispatch:   # Keep manual run capability
-  repository_dispatch:
-    types: [dart-skills-updated] # Listen for this custom ping
+    - cron: '0 0 * * *' # Runs daily at midnight UTC
+  workflow_dispatch: # Allows manual triggering
+
 jobs:
   sync:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
+      # 1. Checkout Flutter Skills (Destination)
       - name: Checkout Flutter Skills (Destination)
-        uses: actions/checkout@v7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Pinned to hash)
         with:
-          # Falls back to the default GITHUB_TOKEN if SYNC_PAT is not defined
-          token: ${{ secrets.SYNC_PAT || github.token }}
-          path: dest_repo
+          token: ${{ secrets.SYNC_PAT || github.token }} # Falls back to default if SYNC_PAT is undefined
 
+      # 2. Checkout Dart Skills (Source)
       - name: Checkout Dart Skills (Source)
-        uses: actions/checkout@v7
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Pinned to hash)
         with:
           repository: dart-lang/skills
           fetch-depth: 50
-          path: src_repo
 
+      # 3. Setup Dart Environment
       - name: Setup Dart Environment
-        uses: dart-lang/setup-dart@v1
+        uses: dart-lang/setup-dart@fed7495a1ee86c728744377be831139154784a0d # v1.6.5 (Pinned to hash)
         with:
           sdk: stable
 
+      # 4. Sync files and copy
       - name: Execute Dart Sync Engine
-        id: sync_engine
         run: |
           cd dest_repo
-          # Run our compiled-on-the-fly Dart script
-          EXIT_CODE=0
-          dart run tool/sync_skills.dart ../src_repo skills || EXIT_CODE=$?
-          
-          if [ $EXIT_CODE -eq 0 ]; then
-            echo "changes_detected=true" >> $GITHUB_OUTPUT
-          elif [ $EXIT_CODE -eq 10 ]; then
-            echo "changes_detected=false" >> $GITHUB_OUTPUT
-            echo "✅ Dart script signaled NO changes were found. Stopping workflow."
-          else
-            echo "❌ Dart script failed with error code $EXIT_CODE"
-            exit $EXIT_CODE
-          fi
+          dart run tool/sync_skills.dart ../src_repo skills
+
+      # 5. Configure Git Credentials under allowlisted Robot Bot
       - name: Configure Git Credentials
         run: |
           git config --global user.name "flutter-skills-sync-bot"
           git config --global user.email "flutter-agent-sync-bot@google.com"
+
+      # 6. Create Pull Request using custom PAT credentials
       - name: Create Pull Request
         if: steps.sync_engine.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@dd475f2b711485001d511ea15a9630c144e59f42 # v7.0.1 (Pinned to hash)
         with:
           token: ${{ secrets.SYNC_PAT || github.token }}
           path: dest_repo
           branch: automation/sync-dart-skills
           title: "🤖 chore: sync skills directory from dart-lang/skills"
           commit-message: "chore: auto-sync skills directory from dart-lang/skills"
-          body: |
-            ### 🤖 Automated Skills Sync & Version Bump (Dart Powered)
-            This is an automated pull request to sync the contents of the `skills/` directory from [dart-lang/skills](https://github.com/dart-lang/skills).
-            
-            This run used a state-tracked Git hash (`.dart_skills_githash`) computed directly by our custom **Dart synchronization utility** (`tool/sync_skills.dart`).
-            
-            ### 🛠️ Changes Performed:
-            * **Preserved:** All native `flutter/*` skills in the repository remain unchanged.
-            * **Synced:** All new, modified, or deleted files inside `dart-lang/skills` have been carried over.
-            * **Bumped:** Automatically incremented the plugin version field in `.claude-plugin/plugin.json` to keep integrations updated.
-          labels: |
-            automated-pr
-            sync
+          committer: flutter-skills-sync-bot <flutter-agent-sync-bot@google.com>
+          author: flutter-skills-sync-bot <flutter-agent-sync-bot@google.com>

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -49,7 +49,10 @@ jobs:
             echo "❌ Dart script failed with error code $EXIT_CODE"
             exit $EXIT_CODE
           fi
-
+      - name: Configure Git Credentials
+        run: |
+          git config --global user.name "flutter-skills-sync-bot"
+          git config --global user.email "flutter-agent-sync-bot@google.com"
       - name: Create Pull Request
         if: steps.sync_engine.outputs.changes_detected == 'true'
         uses: peter-evans/create-pull-request@v8

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -32,7 +32,7 @@ jobs:
 
       # 3. Setup Dart Environment
       - name: Setup Dart Environment
-        uses: dart-lang/setup-dart@b77f714ba35594641a83a71d243c7de39d820474 # v1.6.5 (Pinned to official hash)
+        uses: dart-lang/setup-dart@65eb853c7ba17dde3be364c3d2858773e7144260 # v1.7.2
         with:
           sdk: stable
 

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -1,5 +1,9 @@
 name: Sync Skills Directory
 
+permissions:
+  contents: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 0 * * *' # Runs daily at midnight UTC
@@ -15,6 +19,7 @@ jobs:
         with:
           token: ${{ secrets.SYNC_PAT || github.token }} # Falls back to default if SYNC_PAT is undefined
           persist-credentials: false
+          path: dest_repo
 
       # 2. Checkout Dart Skills (Source)
       - name: Checkout Dart Skills (Source)
@@ -23,6 +28,7 @@ jobs:
           repository: dart-lang/skills
           fetch-depth: 50
           persist-credentials: false
+          path: src_repo
 
       # 3. Setup Dart Environment
       - name: Setup Dart Environment
@@ -32,6 +38,7 @@ jobs:
 
       # 4. Sync files and copy
       - name: Execute Dart Sync Engine
+        id: sync_engine
         run: |
           cd dest_repo
           dart run tool/sync_skills.dart ../src_repo skills
@@ -41,6 +48,8 @@ jobs:
         run: |
           git config --global user.name "flutter-skills-sync-bot"
           git config --global user.email "flutter-agent-sync-bot@google.com"
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || github.token }}
 
       # 6. Create Pull Request using custom PAT credentials
       - name: Create Pull Request

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Pinned to hash)
         with:
           token: ${{ secrets.SYNC_PAT || github.token }} # Falls back to default if SYNC_PAT is undefined
+          persist-credentials: false
 
       # 2. Checkout Dart Skills (Source)
       - name: Checkout Dart Skills (Source)
@@ -21,10 +22,11 @@ jobs:
         with:
           repository: dart-lang/skills
           fetch-depth: 50
+          persist-credentials: false
 
       # 3. Setup Dart Environment
       - name: Setup Dart Environment
-        uses: dart-lang/setup-dart@fed7495a1ee86c728744377be831139154784a0d # v1.6.5 (Pinned to hash)
+        uses: dart-lang/setup-dart@b77f714ba35594641a83a71d243c7de39d820474 # v1.6.5 (Pinned to official hash)
         with:
           sdk: stable
 
@@ -43,7 +45,7 @@ jobs:
       # 6. Create Pull Request using custom PAT credentials
       - name: Create Pull Request
         if: steps.sync_engine.outputs.changes_detected == 'true'
-        uses: peter-evans/create-pull-request@dd475f2b711485001d511ea15a9630c144e59f42 # v7.0.1 (Pinned to hash)
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1 (Pinned to official hash)
         with:
           token: ${{ secrets.SYNC_PAT || github.token }}
           path: dest_repo

--- a/.github/workflows/sync_skills.yaml
+++ b/.github/workflows/sync_skills.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       # 1. Checkout Flutter Skills (Destination)
       - name: Checkout Flutter Skills (Destination)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Pinned to hash)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           token: ${{ secrets.SYNC_PAT || github.token }} # Falls back to default if SYNC_PAT is undefined
           persist-credentials: false
@@ -23,7 +23,7 @@ jobs:
 
       # 2. Checkout Dart Skills (Source)
       - name: Checkout Dart Skills (Source)
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2 (Pinned to hash)
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: dart-lang/skills
           fetch-depth: 50

--- a/tool/dart_skills_lint/README.md
+++ b/tool/dart_skills_lint/README.md
@@ -232,7 +232,7 @@ jobs:
   lint-skills:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: dart-lang/setup-dart@v1
       - run: dart pub global activate dart_skills_lint
       - run: dart pub global run dart_skills_lint --skills-directory ./.claude/skills

--- a/tool/dart_skills_lint/pubspec.yaml
+++ b/tool/dart_skills_lint/pubspec.yaml
@@ -4,6 +4,7 @@ description: >-
   Validates frontmatter, naming, paths, and structure for use in CI and
   pre-commit hooks.
 version: 0.5.0
+resolution: workspace
 repository: https://github.com/flutter/agent-plugins
 issue_tracker: https://github.com/flutter/agent-plugins/issues
 


### PR DESCRIPTION
This configures the git user to be flutter-skills-sync-bot when creating commits that sync the dart-lang/skills into flutter/agent-plugins. The PAT for this account is stored as the SYNC_PAT secret in settings.

This also fixes the zizmor warnings in the GitHub Actions workflows.

See [go/flutter-agent-sync-bot](http://go/flutter-agent-sync-bot) for details.

Fixes #197
