### PR TITLE
use very_good_workflows coverage_excludes

### DIFF
--- a/.github/workflows/dart_skills_lint_workflow.yaml
+++ b/.github/workflows/dart_skills_lint_workflow.yaml
@@ -58,7 +58,7 @@ jobs:
     with:
       working_directory: tool/dart_skills_lint
       min_coverage: 73
-      exclude: '**/*.g.dart'
+      coverage_excludes: '**/*.g.dart'
 
   formatting:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When we updated from very_good_coverage to very_good_workflows to fix zizmor warnings, the key for specifying coverage excludes had changed: https://workflows.vgv.dev/docs/workflows/dart_package#coverage_excludes
