### PR TITLE
add a rule file encouraging proactive use of hot reload

### DIFF
--- a/rules/hot_reload.md
+++ b/rules/hot_reload.md
@@ -5,6 +5,6 @@ description: Proactively connect to apps and hot reload
 ---
 
 Whenever you make edits to any Dart or Flutter files in this project:
-1. Proactively connect to the running application using the `dtd` tool and it's subcommands. Make sure to read the schema for this tool.
+1. Proactively connect to the running application using the `dtd` tool and its subcommands. Make sure to read the schema for this tool.
 2. Trigger a hot reload using the `hot_reload` tool to push the changes immediately.
 3. If no app is running, inform the user but do not let it stop you from completing the code edits.

--- a/rules/hot_reload.md
+++ b/rules/hot_reload.md
@@ -1,0 +1,10 @@
+---
+trigger: glob
+globs: *.dart
+description: Proactively connect to apps and hot reload
+---
+
+Whenever you make edits to any Dart or Flutter files in this project:
+1. Proactively connect to the running application using the `dtd` tool and it's subcommands. Make sure to read the schema for this tool.
+2. Trigger a hot reload using the `hot_reload` tool to push the changes immediately.
+3. If no app is running, inform the user but do not let it stop you from completing the code edits.

--- a/rules/hot_reload.mdc
+++ b/rules/hot_reload.mdc
@@ -1,0 +1,9 @@
+---
+globs: *.dart
+alwaysApply: false
+---
+
+Whenever you make edits to any Dart or Flutter files in this project:
+1. Proactively connect to the running application using the `dtd` tool and its subcommands. Make sure to read the schema for this tool.
+2. Trigger a hot reload using the `hot_reload` tool to push the changes immediately.
+3. If no app is running, inform the user but do not let it stop you from completing the code edits.


### PR DESCRIPTION
Part of https://github.com/dart-lang/ai/issues/498

It is not clear to me exactly which all agents support rules, but AGY does, and this rule has only been tested in AGY. Cursor supports it but seems to want a slightly different format, (`.mdc`).

Should we create separate directories for some of the other agents? I think cursor does support pointing to any directory for the rules in its plugin configuration.

