### PR TITLE
Remove unused dart_code_linter dependency and dead rules config

### DIFF
--- a/tool/dart_skills_lint/analysis_options.yaml
+++ b/tool/dart_skills_lint/analysis_options.yaml
@@ -265,3 +265,4 @@ linter:
     - use_truncating_division
     - valid_regexps
     - void_checks
+    

--- a/tool/dart_skills_lint/analysis_options.yaml
+++ b/tool/dart_skills_lint/analysis_options.yaml
@@ -15,9 +15,6 @@ analyzer:
     strict-casts: true
     strict-inference: true
     strict-raw-types: true
-  # dart_code_linter is intentionally NOT registered as an analyzer
-  # `plugin` here. When it was, `dart analyze` had racy false positives. 
-  # See https://github.com/flutter/agent-plugins/issues/144
   errors:
     # allow deprecated members (we do this because otherwise we have to annotate
     # every member in every test, assert, etc, when we or the Dart SDK deprecates
@@ -268,37 +265,3 @@ linter:
     - use_truncating_division
     - valid_regexps
     - void_checks
-
-dart_code_linter:
-  rules:
-    # Explicit typing
-    - avoid-dynamic
-    - avoid-unnecessary-type-assertions
-    - avoid-unnecessary-type-casts
-    - avoid-unrelated-type-assertions
-    - avoid-collection-methods-with-unrelated-types
-
-    # Predictable structure
-    - avoid-nested-conditional-expressions
-    - no-equal-then-else
-    - no-boolean-literal-compare
-    - no-empty-block
-    - avoid-redundant-async
-    - avoid-passing-async-when-sync-expected
-    # `late` for fields initialized in `setUp` is the idiomatic Dart test
-    # fixture pattern; enforce this rule on lib only.
-    - avoid-late-keyword:
-        exclude:
-          - test/**
-    - prefer-named-record-fields
-
-    # Clean up
-    - avoid-unused-parameters
-    - prefer-moving-to-variable
-    # Test files must be named `*_test.dart` for the test runner, and commonly
-    # hold several small fixture/mock classes, so they can never match this
-    # rule's "file name == first class name" convention. Enforce it on lib only.
-    - prefer-match-file-name:
-        exclude:
-          - test/**
-    - always-remove-listener

--- a/tool/dart_skills_lint/pubspec.yaml
+++ b/tool/dart_skills_lint/pubspec.yaml
@@ -34,7 +34,6 @@ dev_dependencies:
   json_serializable: ^6.7.0
   build_runner: ^2.4.0
   cognitive_complexity: ^0.2.0
-  dart_code_linter: ^4.0.3
   coverage: ^1.15.0
 
 executables:


### PR DESCRIPTION
I should have caught this in https://github.com/flutter/agent-plugins/pull/211 but I thought the analyzer warnings were running an action step. 

- @reidbaker 

---
Relevant prompts 
> Double check that dart_code_linter was giving me a false sense of safety if nothing was running the analyzer checks that are defined. 
> ok cut a pr from the recently updated main and remove that package and any references to it. Open a pr and have the pr description lay out why this code was giving a false sense of security. 

---
Agent authored pr description 
## Summary
Removes `package:dart_code_linter` from `pubspec.yaml` and deletes dead `dart_code_linter:` rules configuration from `analysis_options.yaml`.

## Motivation and Context
`dart_code_linter` was declared as a `dev_dependency` in `pubspec.yaml` and had 15 custom rules configured in `analysis_options.yaml`. However, this package was creating a false sense of security because none of its rules were actually being executed in development or CI.

### Why this code was giving a false sense of security:
1. **Unregistered as an Analyzer Plugin**: `dart_code_linter` was intentionally omitted from `analyzer: plugins:` in `analysis_options.yaml` (due to racy false positives documented in issue #144). Consequently, standard `dart analyze` ignores the `dart_code_linter:` block entirely and only runs standard Dart SDK lints.
2. **Never Executed via CLI**: To run `dart_code_linter` rules without an analyzer plugin, the CLI command `dart run dart_code_linter:metrics analyze lib test` must be invoked. This command was never called in `.github/workflows/`, pre-commit hooks, or developer verification scripts. (Note: CI's `cognitive_complexity` check uses `package:cognitive_complexity`, a separate single-purpose tool).

Removing this unused dependency cleans up dead configuration and removes an unmaintained dev dependency.

## Related Issues
N/A

## What changed
- **`tool/dart_skills_lint/pubspec.yaml`**: Removed `dart_code_linter: ^4.0.3` from `dev_dependencies`.
- **`tool/dart_skills_lint/analysis_options.yaml`**: Removed the dead `dart_code_linter:` configuration section and the accompanying comment explaining why it was omitted from analyzer plugins.

## Testing Instructions
- Run `dart format .` to verify formatting.
- Run `dart analyze --fatal-infos` to verify static analysis.
- Run `dart run cognitive_complexity --fail-threshold 48 tool/dart_skills_lint/lib tool/dart_skills_lint/test` to verify complexity metrics.
- Run `dart test` to verify unit tests.
- Run `dart run bin/cli.dart -d .agents/skills` to validate repository skills.