### PR TITLE
Formatting Fix for the Codex Plugin Title in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ claude plugin install dart-flutter@dart-flutter
 ```bash
 claude plugin marketplace list
 ```
-\n### Codex Plugin
+### Codex Plugin
 
 Add the Dart and Flutter marketplace for Codex plugins:
 


### PR DESCRIPTION
Removed the unnecessary `\n` .

Before:
<img width="921" height="325" alt="before" src="https://github.com/user-attachments/assets/ab9e045c-31be-4b77-adfc-e84a4f5fdf56" />

After:
<img width="931" height="346" alt="after" src="https://github.com/user-attachments/assets/b6ec6c32-3900-46cb-b683-2a22a45edf34" />
